### PR TITLE
Improved error handling and a bonus status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Build the main.go file to a location on your path. You can use the buildtohomebi
 Reload a script file in the specified app and print metadata. The script file path is local, the app name/path is from within the engine docker file system.
 If the `--app` parameter is left out the tool will use a session app instead.
 ```bash
-corectl --app myapp.qvf reload myscript.qvs
+corectl --app myapp.qvf reload --script myscript.qvs
 ```
 
 Print the metadata with reload
@@ -76,7 +76,7 @@ corectl --app myapp.qvf eval "=A+B+C"
 
 Specify what Qlik Associative Engine to use with the --engine parameter
 ```bash
-corectl --engine remoteengine:9076 --app myapp.qvf reload myscript.qvs
+corectl --engine remoteengine:9076 --app myapp.qvf reload --script myscript.qvs
 ```
 
 Print some extra debugging information using --verbose flag

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Build the main.go file to a location on your path. You can use the buildtohomebi
 ```
 
 ## Example Usage
+
 Reload a script file in the specified app and print metadata. The script file path is local, the app name/path is from within the engine docker file system.
+If the `--app` parameter is left out the tool will use a session app instead.
 ```bash
 corectl --app myapp.qvf reload myscript.qvs
 ```

--- a/internal/eval.go
+++ b/internal/eval.go
@@ -12,6 +12,9 @@ import (
 
 // Eval builds a straight table  hypercube based on the supplied argument, evaluates it and prints the result to system out.
 func Eval(ctx context.Context, doc *enigma.Doc, args []string) {
+
+	ensureModelExists(ctx, doc)
+
 	measures, dims := argumentsToMeasuresAndDims(args)
 	object, _ := doc.CreateSessionObject(ctx, &enigma.GenericObjectProperties{
 		Info: &enigma.NxInfo{

--- a/internal/field.go
+++ b/internal/field.go
@@ -9,6 +9,7 @@ import (
 
 // PrintField prints the first few rows of a field to system out.
 func PrintField(ctx context.Context, doc *enigma.Doc, fieldName string) {
+	ensureModelExists(ctx, doc)
 	fmt.Print(getFieldContentAsTable(ctx, doc, fieldName, 100))
 }
 

--- a/internal/modeldata.go
+++ b/internal/modeldata.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/qlik-oss/enigma-go"
@@ -121,12 +122,10 @@ func addTableFieldCellCrossReferences(fields []*FieldModel, tables []*TableModel
 func GetModelMetadata(ctx context.Context, doc *enigma.Doc, metaURL string, keyOnly bool) *ModelMetadata {
 	tables, sourceKeys, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 	if len(tables) == 0 {
-		fmt.Println("The data model is empty.")
-		os.Exit(1)
+		log.Fatalln("The data model is empty.")
 	}
 	restMetadata, err := ReadRestMetadata(metaURL)
 
@@ -195,11 +194,9 @@ type FieldSourceTableInfo struct {
 func ensureModelExists(ctx context.Context, doc *enigma.Doc) {
 	tables, _, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 	if len(tables) == 0 {
-		fmt.Println("The data model is empty.")
-		os.Exit(1)
+		log.Fatalln("The data model is empty.")
 	}
 }

--- a/internal/modeldata.go
+++ b/internal/modeldata.go
@@ -3,8 +3,9 @@ package internal
 import (
 	"context"
 	"fmt"
-	"github.com/qlik-oss/enigma-go"
 	"os"
+
+	"github.com/qlik-oss/enigma-go"
 )
 
 // ModelMetadata defines all available metadata around the data model.
@@ -190,7 +191,7 @@ type FieldSourceTableInfo struct {
 	KeyType     string
 }
 
-// Exists if there  is no data model
+// Exits if there is no data model
 func ensureModelExists(ctx context.Context, doc *enigma.Doc) {
 	tables, _, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
 	if err != nil {

--- a/internal/modeldata.go
+++ b/internal/modeldata.go
@@ -202,11 +202,3 @@ func ensureModelExists(ctx context.Context, doc *enigma.Doc) {
 		os.Exit(1)
 	}
 }
-
-func DataModelTableCount(ctx context.Context, doc *enigma.Doc) int {
-	tables, _, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
-	if err != nil {
-		return 0
-	}
-	return len(tables)
-}

--- a/internal/modeldata.go
+++ b/internal/modeldata.go
@@ -121,7 +121,11 @@ func GetModelMetadata(ctx context.Context, doc *enigma.Doc, metaURL string, keyO
 	tables, sourceKeys, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(-1)
+		os.Exit(1)
+	}
+	if len(tables) == 0 {
+		fmt.Println("The data model is empty.")
+		os.Exit(1)
 	}
 	restMetadata, err := ReadRestMetadata(metaURL)
 
@@ -184,4 +188,25 @@ func tableRecordsToMapMap(tables []*enigma.TableRecord) map[string]map[string]*e
 type FieldSourceTableInfo struct {
 	CellContent string
 	KeyType     string
+}
+
+// Exists if there  is no data model
+func ensureModelExists(ctx context.Context, doc *enigma.Doc) {
+	tables, _, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if len(tables) == 0 {
+		fmt.Println("The data model is empty.")
+		os.Exit(1)
+	}
+}
+
+func DataModelTableCount(ctx context.Context, doc *enigma.Doc) int {
+	tables, _, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
+	if err != nil {
+		return 0
+	}
+	return len(tables)
 }

--- a/internal/restapi.go
+++ b/internal/restapi.go
@@ -9,6 +9,9 @@ import (
 
 // ReadRestMetadata fetches metadata from the rest api.
 func ReadRestMetadata(url string) (*RestMetadata, error) {
+	if url == "" {
+		return nil, nil
+	}
 	response, err := http.Get(url)
 	if err != nil {
 		fmt.Printf("The HTTP request failed with error %s\n", err)

--- a/internal/script.go
+++ b/internal/script.go
@@ -2,8 +2,9 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
-	"log"
+	"os"
 
 	"github.com/qlik-oss/enigma-go"
 )
@@ -12,7 +13,9 @@ import (
 func SetScript(ctx context.Context, doc *enigma.Doc, scriptFilePath string) {
 	loadScript, err := ioutil.ReadFile(scriptFilePath)
 	if err != nil {
-		log.Fatalln("Could not find load script: %s", scriptFilePath)
+		fmt.Printf("Could not find load script: %s", scriptFilePath)
+		os.Exit(1)
 	}
+
 	err = doc.SetScript(ctx, string(loadScript))
 }

--- a/internal/script.go
+++ b/internal/script.go
@@ -13,7 +13,7 @@ func SetScript(ctx context.Context, doc *enigma.Doc, scriptFilePath string) {
 	loadScript, err := ioutil.ReadFile(scriptFilePath)
 	if err != nil {
 		fmt.Printf("Could not find load script: %s", scriptFilePath)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 	err = doc.SetScript(ctx, string(loadScript))
 }

--- a/internal/script.go
+++ b/internal/script.go
@@ -2,18 +2,17 @@ package internal
 
 import (
 	"context"
-	"fmt"
-	"github.com/qlik-oss/enigma-go"
 	"io/ioutil"
-	"os"
+	"log"
+
+	"github.com/qlik-oss/enigma-go"
 )
 
 // SetScript loads the script file and sets it in the app.
 func SetScript(ctx context.Context, doc *enigma.Doc, scriptFilePath string) {
 	loadScript, err := ioutil.ReadFile(scriptFilePath)
 	if err != nil {
-		fmt.Printf("Could not find load script: %s", scriptFilePath)
-		os.Exit(1)
+		log.Fatalln("Could not find load script: %s", scriptFilePath)
 	}
 	err = doc.SetScript(ctx, string(loadScript))
 }

--- a/internal/state.go
+++ b/internal/state.go
@@ -67,8 +67,6 @@ func PrepareEngineState(ctx context.Context, engine string, sessionID string, ap
 		} else {
 			doc, err = global.OpenDoc(ctx, appID, "", "", "", false)
 			if doc != nil {
-				log.Fatalln(err)
-			} else if doc != nil {
 				LogVerbose("App:  " + appID + "(opened)")
 			} else {
 				_, _, err = global.CreateApp(ctx, appID, "")

--- a/internal/state.go
+++ b/internal/state.go
@@ -66,7 +66,7 @@ func PrepareEngineState(ctx context.Context, engine string, sessionID string, ap
 			}
 		} else {
 			doc, err = global.OpenDoc(ctx, appID, "", "", "", false)
-			if err != nil {
+			if doc != nil {
 				log.Fatalln(err)
 			} else if doc != nil {
 				LogVerbose("App:  " + appID + "(opened)")

--- a/internal/state.go
+++ b/internal/state.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	neturl "net/url"
 	"os"
@@ -61,23 +62,22 @@ func PrepareEngineState(ctx context.Context, engine string, sessionID string, ap
 			if doc != nil {
 				LogVerbose("Session app (new)")
 			} else {
-				fmt.Println(err)
-				os.Exit(1)
+				log.Fatalln(err)
 			}
 		} else {
 			doc, err = global.OpenDoc(ctx, appID, "", "", "", false)
-			if doc != nil {
+			if err != nil {
+				log.Fatalln(err)
+			} else if doc != nil {
 				LogVerbose("App:  " + appID + "(opened)")
 			} else {
 				_, _, err = global.CreateApp(ctx, appID, "")
 				if err != nil {
-					fmt.Println(err)
-					os.Exit(1)
+					log.Fatalln(err)
 				}
 				doc, err = global.OpenDoc(ctx, appID, "", "", "", false)
 				if err != nil {
-					fmt.Println(err)
-					os.Exit(1)
+					log.Fatalln(err)
 				}
 				if doc != nil {
 					LogVerbose("Document: " + appID + "(new)")

--- a/internal/state.go
+++ b/internal/state.go
@@ -33,13 +33,11 @@ func PrepareEngineState(ctx context.Context, engine string, sessionID string, ap
 
 	LogVerbose("SessionId: " + sessionID)
 	headers := make(http.Header, 1)
-	if sessionID != "" {
-		headers.Set("X-Qlik-Session", sessionID)
-	}
+	headers.Set("X-Qlik-Session", sessionID)
 	global, err := enigma.Dialer{}.Dial(ctx, engineURL, headers)
 	if err != nil {
 		fmt.Println("Could not connect to engine:"+engine, err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 
 	go func() {
@@ -49,32 +47,28 @@ func PrepareEngineState(ctx context.Context, engine string, sessionID string, ap
 			}
 		}
 	}()
-	if sessionID != "" {
-		doc, err = global.GetActiveDoc(ctx)
-		if doc != nil {
-			appID := "SessionDoc"
-			LogVerbose("Document: " + appID + "(reconnected)")
+	doc, err = global.GetActiveDoc(ctx)
+	if doc != nil {
+		// There is an already opened doc!
+		if appID != "" {
+			LogVerbose("App: " + appID + "(reconnected)")
 		} else {
-			LogVerbose("No active doc: " + appID + ", session=" + sessionID)
+			LogVerbose("Session app (reconnected)")
 		}
-	}
-	if doc == nil {
+	} else {
 		if appID == "" {
 			doc, err = global.CreateSessionApp(ctx)
 			if doc != nil {
-				appID = doc.GenericId
-				LogVerbose("Document: " + appID + "(new session app)")
+				LogVerbose("Session app (new)")
 			} else {
 				fmt.Println(err)
+				os.Exit(1)
 			}
 		} else {
-			if doc == nil {
-				doc, err = global.OpenDoc(ctx, appID, "", "", "", false)
-				if doc != nil {
-					LogVerbose("Document: " + appID + "(opened)")
-				}
-			}
-			if doc == nil {
+			doc, err = global.OpenDoc(ctx, appID, "", "", "", false)
+			if doc != nil {
+				LogVerbose("App:  " + appID + "(opened)")
+			} else {
 				_, _, err = global.CreateApp(ctx, appID, "")
 				if err != nil {
 					fmt.Println(err)
@@ -125,6 +119,9 @@ func buildWebSocketURL(engine string, ttl string) string {
 }
 
 func buildMetadataURL(engine string, appID string) string {
+	if appID == "" {
+		return ""
+	}
 	engine = tidyUpEngine(engine)
 	engine = strings.Replace(engine, "wss://", "https://", -1)
 	engine = strings.Replace(engine, "ws://", "http://", -1)

--- a/main.go
+++ b/main.go
@@ -75,8 +75,8 @@ var (
 			if appID == "" {
 				fmt.Println("Using session app")
 			}
-      
-      sessionID := getSessionID(appID)
+
+			sessionID := getSessionID(appID)
 
 			state = internal.PrepareEngineState(ctx, engine, sessionID, appID, ttl)
 		},

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ var (
 			engine := viper.GetString("engine")
 			appID := viper.GetString("app")
 			ttl := viper.GetString("ttl")
-			sessionID := getSessionId(appID)
+			sessionID := getSessionID(appID)
 			state = internal.PrepareEngineState(ctx, engine, sessionID, appID, ttl)
 		},
 
@@ -219,24 +219,12 @@ var (
 		Long:  "Prints status info about the connection to engine and current app",
 
 		Run: func(ccmd *cobra.Command, args []string) {
-			if state.AppID != "" {
-				fmt.Println("Connected to " + state.AppID + " @ " + viper.GetString("engine") + " with sid=" + getSessionId(state.AppID))
-			} else {
-				fmt.Println("Connected to session app @ " + viper.GetString("engine") + " with sid=" + getSessionId(state.AppID))
-			}
-			tableCount := internal.DataModelTableCount(state.Ctx, state.Doc)
-			if tableCount == 0 {
-				fmt.Println("The data model is empty.")
-			} else if tableCount == 1 {
-				fmt.Println("The data model has 1 table.")
-			} else {
-				fmt.Printf("The data model has %d tables.", tableCount)
-			}
+			printer.PrintStatus(state)
 		},
 	}
 )
 
-func getSessionId(appID string) string {
+func getSessionID(appID string) string {
 	currentUser, err := user.Current()
 	if err != nil {
 		fmt.Println(err)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -149,8 +150,7 @@ var (
 
 			script, err := doc.GetScript(ctx)
 			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
+				log.Fatalln(err)
 			}
 
 			fmt.Println(script)
@@ -227,13 +227,11 @@ var (
 func getSessionID(appID string) string {
 	currentUser, err := user.Current()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 	hostName, err := os.Hostname()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 	sessionID := base64.StdEncoding.EncodeToString([]byte("Corectl-" + currentUser.Username + "-" + hostName + "-" + appID))
 	return sessionID

--- a/printer/status.go
+++ b/printer/status.go
@@ -1,0 +1,37 @@
+package printer
+
+import (
+	"context"
+	"fmt"
+	"github.com/qlik-oss/corectl/internal"
+	"github.com/qlik-oss/enigma-go"
+	"github.com/spf13/viper"
+)
+
+//PrintStatus prints the name of the app and the engine corectl is connected to.
+// It also prints if the data model is empty or not
+func PrintStatus(state *internal.State) {
+	if state.AppID != "" {
+		fmt.Println("Connected to " + state.AppID + " @ " + viper.GetString("engine"))
+	} else {
+		fmt.Println("Connected to session app @ " + viper.GetString("engine"))
+	}
+	tableCount := dataModelTableCount(state.Ctx, state.Doc)
+	if tableCount == 0 {
+		fmt.Println("The data model is empty.")
+	} else if tableCount == 1 {
+		fmt.Println("The data model has 1 table.")
+	} else {
+		fmt.Printf("The data model has %d tables.", tableCount)
+	}
+
+}
+
+//Returns the number of
+func dataModelTableCount(ctx context.Context, doc *enigma.Doc) int {
+	tables, _, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
+	if err != nil {
+		return 0
+	}
+	return len(tables)
+}

--- a/printer/status.go
+++ b/printer/status.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"context"
 	"fmt"
+
 	"github.com/qlik-oss/corectl/internal"
 	"github.com/qlik-oss/enigma-go"
 	"github.com/spf13/viper"
@@ -27,7 +28,7 @@ func PrintStatus(state *internal.State) {
 
 }
 
-//Returns the number of
+// Returns the number of tables in the data model
 func dataModelTableCount(ctx context.Context, doc *enigma.Doc) int {
 	tables, _, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
 	if err != nil {

--- a/printer/status.go
+++ b/printer/status.go
@@ -20,8 +20,6 @@ func PrintStatus(state *internal.State) {
 	tableCount := dataModelTableCount(state.Ctx, state.Doc)
 	if tableCount == 0 {
 		fmt.Println("The data model is empty.")
-	} else if tableCount == 1 {
-		fmt.Println("The data model has 1 table.")
 	} else {
 		fmt.Printf("The data model has %d tables.", tableCount)
 	}

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -92,6 +92,9 @@ func TestCorectl(t *testing.T) {
 
 		{"reload project 2", []string{"--config=test/project2/qli.yml ", connectToEngine, "reload"}, "project2-reload.golden"},
 		{"fields project 2", []string{"--config=test/project2/qli.yml ", connectToEngine, "fields"}, "project2-fields.golden"},
+
+		{"reload project 2", []string{"--config=test/project3/qli.yml ", connectToEngine, "reload"}, "project3-reload.golden"},
+		{"fields project 2", []string{"--config=test/project3/qli.yml ", connectToEngine, "fields"}, "project3-fields.golden"},
 	}
 
 	for _, tt := range tests {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -93,8 +93,8 @@ func TestCorectl(t *testing.T) {
 		{"reload project 2", []string{"--config=test/project2/qli.yml ", connectToEngine, "reload"}, "project2-reload.golden"},
 		{"fields project 2", []string{"--config=test/project2/qli.yml ", connectToEngine, "fields"}, "project2-fields.golden"},
 
-		{"reload project 2", []string{"--config=test/project3/qli.yml ", connectToEngine, "reload"}, "project3-reload.golden"},
-		{"fields project 2", []string{"--config=test/project3/qli.yml ", connectToEngine, "fields"}, "project3-fields.golden"},
+		{"reload project 3", []string{"--config=test/project3/qli.yml ", connectToEngine, "reload"}, "project3-reload.golden"},
+		{"fields project 3", []string{"--config=test/project3/qli.yml ", connectToEngine, "fields"}, "project3-fields.golden"},
 	}
 
 	for _, tt := range tests {

--- a/test/golden/project3-fields.golden
+++ b/test/golden/project3-fields.golden
@@ -1,3 +1,4 @@
+Using session app
 No REST metadata available.
 Field        Uniq/Tot   RAM   Tags                 datacsv   Sample content
 a            1          11    $numeric, $integer   1/1       1   

--- a/test/golden/project3-fields.golden
+++ b/test/golden/project3-fields.golden
@@ -1,0 +1,8 @@
+No REST metadata available.
+Field        Uniq/Tot   RAM   Tags                 datacsv   Sample content
+a            1          11    $numeric, $integer   1/1       1   
+b            1          11    $numeric, $integer   1/1       2   
+c            1          11    $numeric, $integer   1/1       3   
+                                                   
+Total RAM               N/A                        N/A
+

--- a/test/golden/project3-reload.golden
+++ b/test/golden/project3-reload.golden
@@ -1,2 +1,3 @@
+Using session app
 datacsv << data 1 Lines fetched
 Reload finished successfully

--- a/test/golden/project3-reload.golden
+++ b/test/golden/project3-reload.golden
@@ -1,0 +1,2 @@
+datacsv << data 1 Lines fetched
+Reload finished successfully

--- a/test/project3/qli.yml
+++ b/test/project3/qli.yml
@@ -1,0 +1,5 @@
+engine: localhost:9076
+script: ./script.qvs
+connections:
+  testdata:
+    path: /data

--- a/test/project3/script.qvs
+++ b/test/project3/script.qvs
@@ -1,0 +1,5 @@
+datacsv:
+LOAD
+  *
+FROM [lib://testdata/data.csv]
+(txt, utf8, embedded labels, delimiter is ',');


### PR DESCRIPTION
Fixes #34, #30, #17
- Added a check that there is at least one table in all view commands (fields, eval etc)
- Made session id more unique (but still persistent) not to clash if more than one user accesses the same engine
- No more accidental creation of unnamed apps. If no app is specified a session app is used.
- Added a new status command which sometimes is needed to understand issues where corectl is accidentally connected to the wrong engine or wrong app (for instance when pointing at the wrong config file).