### PR TITLE
Add silent flag for opting out of reload progress

### DIFF
--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -16,6 +16,7 @@ corectl reload [flags]
       --connections string   path to connections file
   -h, --help                 help for reload
       --script string        Script file name
+      --silent               Do not log reload progress
 ```
 
 ### Options inherited from parent commands

--- a/internal/reload.go
+++ b/internal/reload.go
@@ -11,15 +11,15 @@ import (
 
 // Reload reloads the app and prints the progress to system out. If true is supplied to skipTransientLogs
 // the live ticking of table row counts is disabled (useful for testing).
-func Reload(ctx context.Context, doc *enigma.Doc, global *enigma.Global, verboseLogging bool, skipTransientLogs bool) {
+func Reload(ctx context.Context, doc *enigma.Doc, global *enigma.Global, silent bool, skipTransientLogs bool) {
 
 	var (
 		reloadSuccessful bool
 		err              error
 	)
 
-	// Only log reload progress if verbose logging is enabled
-	if verboseLogging {
+	// Log progress unless silent flag was passed in to the reload command
+	if !silent {
 		reloadDone := make(chan struct{})
 		ctxWithReservedRequestID, reservedRequestID := doc.WithReservedRequestID(ctx)
 		go func() {

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 var (
 	state  *internal.State
 	config string
+	silent bool
 
 	corectlCommand = &cobra.Command{
 		Hidden:            true,
@@ -216,7 +217,7 @@ var (
 				internal.SetScript(ctx, doc, scriptFile)
 			}
 
-			internal.Reload(ctx, doc, global, internal.QliVerbose, true)
+			internal.Reload(ctx, doc, global, silent, true)
 			if state.AppID != "" {
 				internal.Save(ctx, doc, state.AppID)
 			}
@@ -318,10 +319,8 @@ func init() {
 	viper.BindPFlag("select", fieldsCommand.PersistentFlags().Lookup("select"))
 
 	reloadCmd.PersistentFlags().String("connections", "", "path to connections file")
-	//viper.BindPFlag("connections", reloadCmd.PersistentFlags().Lookup("connections"))
-
 	reloadCmd.PersistentFlags().String("script", "", "Script file name")
-	//viper.BindPFlag("script", reloadCmd.PersistentFlags().Lookup("script"))
+	reloadCmd.Flags().BoolVar(&silent, "silent", false, "Do not log reload progress")
 
 	// commands
 	corectlCommand.AddCommand(reloadCmd)

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -90,6 +90,7 @@ func TestCorectlGolden(t *testing.T) {
 		{"fields project 1", []string{"--config=test/project1/qli.yml ", connectToEngine, "fields"}, "project1-fields.golden"},
 		{"field numbers project 1", []string{"--config=test/project1/qli.yml ", connectToEngine, "field", "numbers"}, "project1-field-numbers.golden"},
 		{"eval project 1", []string{"--config=test/project1/qli.yml ", connectToEngine, "eval", "count(numbers)", "by", "xyz"}, "project1-eval-1.golden"},
+		{"reload project1 without progress", []string{"--config=test/project1/qli.yml", connectToEngine, "reload", "--silent"}, "project1-reload-silent.golden"},
 
 		{"reload project 2", []string{"--config=test/project2/qli.yml ", connectToEngine, "reload"}, "project2-reload.golden"},
 		{"fields project 2", []string{"--config=test/project2/qli.yml ", connectToEngine, "fields"}, "project2-fields.golden"},
@@ -129,9 +130,6 @@ func TestCorectlContains(t *testing.T) {
 		args     []string
 		contains []string
 	}{
-		{"reload progress project 1", []string{"--config=test/project1/qli.yml", connectToEngine, "--verbose", "reload"}, []string{"Connected", "TableA <<  5 Lines fetched", "TableB <<  5 Lines fetched"}},
-		{"reload progress project 2", []string{"--config=test/project2/qli.yml ", connectToEngine, "--verbose", "reload"}, []string{"datacsv << data 1 Lines fetched"}},
-		{"reload progress project 3", []string{"--config=test/project3/qli.yml ", connectToEngine, "--verbose", "reload"}, []string{"datacsv << data 1 Lines fetched"}},
 		{"list apps", []string{connectToEngine, "apps"}, []string{"Name", "Last Reloaded", "ReadOnly", "Title", "project2.qvf", "project1.qvf"}},
 	}
 

--- a/test/golden/project1-reload-silent.golden
+++ b/test/golden/project1-reload-silent.golden
@@ -1,4 +1,3 @@
-datacsv << data 1 Lines fetched
 Reload finished successfully
 Saving...Done
 

--- a/test/golden/project1-reload.golden
+++ b/test/golden/project1-reload.golden
@@ -1,3 +1,6 @@
+Connected
+TableA <<  5 Lines fetched
+TableB <<  5 Lines fetched
 Reload finished successfully
 Saving...Done
 

--- a/test/golden/project3-reload.golden
+++ b/test/golden/project3-reload.golden
@@ -1,2 +1,3 @@
 No app specified, using session app instead
+datacsv << data 1 Lines fetched
 Reload finished successfully


### PR DESCRIPTION
Earlier the reload progress was tied to the `--verbose` flag which enabled more than just reload progress logging. This PR adds a `--silent` flag for the `reload` command for opting out of reload progress. By default the reload progress logging will be enabled.