### PR TITLE
Update release flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,11 @@ workflows:
   version: 2
   build_and_publish:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only:
+                - /v.*/
       - publish:
           requires:
             - build


### PR DESCRIPTION
Tags needs to be whitelisted and not blacklisted to run.