### PR TITLE
Support headers as parameters and in config

### DIFF
--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -13,12 +13,13 @@ corectl [flags]
 ### Options
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-  -h, --help            help for corectl
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -h, --help                     help for corectl
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_apps.md
+++ b/docs/corectl_apps.md
@@ -20,11 +20,12 @@ corectl apps [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_assoc.md
+++ b/docs/corectl_assoc.md
@@ -19,11 +19,12 @@ corectl assoc [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_data.md
+++ b/docs/corectl_data.md
@@ -21,11 +21,12 @@ corectl data [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -19,11 +19,12 @@ corectl eval <measure 1> [<measure 2...>] by <dimension 1> [<dimension 2...] [fl
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_field.md
+++ b/docs/corectl_field.md
@@ -19,11 +19,12 @@ corectl field <field name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_fields.md
+++ b/docs/corectl_fields.md
@@ -19,11 +19,12 @@ corectl fields [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_keys.md
+++ b/docs/corectl_keys.md
@@ -19,11 +19,12 @@ corectl keys [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_layout.md
+++ b/docs/corectl_layout.md
@@ -21,11 +21,12 @@ corectl layout [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_meta.md
+++ b/docs/corectl_meta.md
@@ -19,11 +19,12 @@ corectl meta [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_objects.md
+++ b/docs/corectl_objects.md
@@ -20,11 +20,12 @@ corectl objects [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_properties.md
+++ b/docs/corectl_properties.md
@@ -21,11 +21,12 @@ corectl properties [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -25,11 +25,12 @@ corectl reload [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_script.md
+++ b/docs/corectl_script.md
@@ -19,11 +19,12 @@ corectl script [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_status.md
+++ b/docs/corectl_status.md
@@ -19,11 +19,12 @@ corectl status [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_tables.md
+++ b/docs/corectl_tables.md
@@ -19,11 +19,12 @@ corectl tables [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_update.md
+++ b/docs/corectl_update.md
@@ -24,11 +24,12 @@ corectl update [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -19,11 +19,12 @@ corectl version [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO

--- a/internal/modeldata.go
+++ b/internal/modeldata.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/qlik-oss/enigma-go"
@@ -118,7 +119,7 @@ func addTableFieldCellCrossReferences(fields []*FieldModel, tables []*TableModel
 }
 
 // GetModelMetadata retrives all available metadata about the app
-func GetModelMetadata(ctx context.Context, doc *enigma.Doc, metaURL string, keyOnly bool) *ModelMetadata {
+func GetModelMetadata(ctx context.Context, doc *enigma.Doc, metaURL string, headers http.Header, keyOnly bool) *ModelMetadata {
 	tables, sourceKeys, err := doc.GetTablesAndKeys(ctx, &enigma.Size{}, &enigma.Size{}, 0, false, false)
 	if err != nil {
 		FatalError(err)
@@ -126,7 +127,7 @@ func GetModelMetadata(ctx context.Context, doc *enigma.Doc, metaURL string, keyO
 	if len(tables) == 0 {
 		FatalError("The data model is empty.")
 	}
-	restMetadata, err := ReadRestMetadata(metaURL)
+	restMetadata, err := ReadRestMetadata(metaURL, headers)
 
 	if len(tables) > 0 && restMetadata == nil {
 		fmt.Println("No REST metadata available.")

--- a/internal/restapi.go
+++ b/internal/restapi.go
@@ -8,11 +8,17 @@ import (
 )
 
 // ReadRestMetadata fetches metadata from the rest api.
-func ReadRestMetadata(url string) (*RestMetadata, error) {
+func ReadRestMetadata(url string, headers http.Header) (*RestMetadata, error) {
 	if url == "" {
 		return nil, nil
 	}
-	response, err := http.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fmt.Printf("The HTTP request failed with error %s\n", err)
+		return nil, err
+	}
+	req.Header = headers
+	response, err := http.DefaultClient.Do(req)
 	if err != nil {
 		fmt.Printf("The HTTP request failed with error %s\n", err)
 		return nil, err
@@ -21,6 +27,7 @@ func ReadRestMetadata(url string) (*RestMetadata, error) {
 		return nil, nil
 	}
 	data, _ := ioutil.ReadAll(response.Body)
+	defer response.Body.Close()
 	result := &RestMetadata{}
 	json.Unmarshal(data, result)
 	return result, nil

--- a/internal/restapi.go
+++ b/internal/restapi.go
@@ -23,11 +23,11 @@ func ReadRestMetadata(url string, headers http.Header) (*RestMetadata, error) {
 		fmt.Printf("The HTTP request failed with error %s\n", err)
 		return nil, err
 	}
+	defer response.Body.Close()
 	if response.StatusCode != 200 {
 		return nil, nil
 	}
 	data, _ := ioutil.ReadAll(response.Body)
-	defer response.Body.Close()
 	result := &RestMetadata{}
 	json.Unmarshal(data, result)
 	return result, nil

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ var (
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			state := internal.PrepareEngineState(rootCtx, params.engine, params.appID, params.ttl, params.headers, false)
-			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, false)
+			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, params.headers, false)
 			printer.PrintFields(data, false)
 		},
 	}
@@ -91,7 +91,7 @@ var (
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			state := internal.PrepareEngineState(rootCtx, params.engine, params.appID, params.ttl, params.headers, false)
-			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, true)
+			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, params.headers, true)
 			printer.PrintFields(data, true)
 		},
 	}
@@ -103,7 +103,7 @@ var (
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			state := internal.PrepareEngineState(rootCtx, params.engine, params.appID, params.ttl, params.headers, false)
-			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, false)
+			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, params.headers, false)
 			printer.PrintAssociations(data)
 		},
 	}
@@ -115,7 +115,7 @@ var (
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			state := internal.PrepareEngineState(rootCtx, params.engine, params.appID, params.ttl, params.headers, false)
-			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, false)
+			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, params.headers, false)
 			printer.PrintTables(data)
 		},
 	}
@@ -157,7 +157,7 @@ var (
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			state := internal.PrepareEngineState(rootCtx, params.engine, params.appID, params.ttl, params.headers, false)
-			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, false)
+			data := internal.GetModelMetadata(rootCtx, state.Doc, state.MetaURL, params.headers, false)
 			printer.PrintMetadata(data)
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 )
 
 var (
+	headersMap         = make(map[string]string)
 	explicitConfigFile = ""
 	version            = ""
 	params             struct {
@@ -60,7 +61,10 @@ var (
 			params.engine = viper.GetString("engine")
 			params.appID = viper.GetString("app")
 			params.ttl = viper.GetString("ttl")
-			headersMap := viper.GetStringMapString("headers")
+
+			if len(headersMap) == 0 {
+				headersMap = viper.GetStringMapString("headers")
+			}
 			params.headers = make(http.Header, 1)
 			for key, value := range headersMap {
 				params.headers.Set(key, value)
@@ -334,6 +338,9 @@ func init() {
 
 	corectlCommand.PersistentFlags().StringP("app", "a", "", "App name including .qvf file ending. If no app is specified a session app is used instead.")
 	viper.BindPFlag("app", corectlCommand.PersistentFlags().Lookup("app"))
+
+	//not binding to viper since binding a map does not seem to work.
+	corectlCommand.PersistentFlags().StringToStringVar(&headersMap, "headers", nil, "Headers to use when connecting to qix engine")
 
 	corectlCommand.PersistentFlags().BoolP("verbose", "v", false, "Logs extra information")
 	viper.BindPFlag("verbose", corectlCommand.PersistentFlags().Lookup("verbose"))

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -107,6 +107,9 @@ func TestCorectlGolden(t *testing.T) {
 		{"project 3 - fields", []string{"--config=test/project3/corectl.yml ", connectToEngine, "fields"}, "project3-fields.golden"},
 		{"err 2", []string{connectToEngine, "--app=nosuchapp.qvf", "eval", "count(numbers)", "by", "xyz"}, "err-2.golden"},
 		{"err 3", []string{connectToEngine, "--app=project1.qvf", "--object=nosuchobject", "data"}, "err-3.golden"},
+
+		// Project 4 has no JWT
+		{"err jwt", []string{connectToEngine, "apps"}, "err-jwt.golden"},
 	}
 
 	for _, tt := range tests {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -107,9 +107,6 @@ func TestCorectlGolden(t *testing.T) {
 		{"project 3 - fields", []string{"--config=test/project3/corectl.yml ", connectToEngine, "fields"}, "project3-fields.golden"},
 		{"err 2", []string{connectToEngine, "--app=nosuchapp.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "eval", "count(numbers)", "by", "xyz"}, "err-2.golden"},
 		{"err 3", []string{connectToEngine, "--app=project1.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "--object=nosuchobject", "data"}, "err-3.golden"},
-
-		// Project 4 has no JWT
-		{"err jwt", []string{connectToEngine, "apps"}, "err-jwt.golden"},
 	}
 
 	for _, tt := range tests {
@@ -149,6 +146,8 @@ func TestCorectlContains(t *testing.T) {
 		{"list apps", []string{connectToEngine, "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "apps"}, []string{"Id", "Name", "Last-Reloaded", "ReadOnly", "Title", "project2.qvf", "project1.qvf"}},
 		{"list apps json", []string{connectToEngine, "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "apps", "--json"}, []string{"\"id\": \"/apps/project2.qvf\","}},
 		{"err 1", []string{"--engine=localhost:9999", "fields"}, []string{"Please check the --engine parameter or your config file", "Error details:  dial tcp"}},
+		// trying to connect to an engine that has JWT authorization activated without a JWT Header
+		{"err jwt", []string{connectToEngine, "apps"}, []string{"Error details:  401 from ws server: websocket: bad handshake"}},
 	}
 
 	for _, tt := range tests {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -99,14 +99,14 @@ func TestCorectlGolden(t *testing.T) {
 		{"project 1 - reload without progress", []string{"--config=test/project1/corectl.yml", connectToEngine, "reload", "--silent"}, "project1-reload-silent.golden"},
 
 		// Project 2 has separate connections file
-		{"project 2 - reload with connections", []string{connectToEngine, "-a=project2.qvf", "reload", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, "project2-reload.golden"},
+		{"project 2 - reload with connections", []string{connectToEngine, "-a=project2.qvf", "reload", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json --headers authorization=\"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0\""}, "project2-reload.golden"},
 		{"project 2 - fields ", []string{"--config=test/project2/corectl.yml ", connectToEngine, "fields"}, "project2-fields.golden"},
 		{"project 2 - data", []string{"--config=test/project2/corectl.yml ", connectToEngine, "--object", "my-hypercube-on-commandline", "data"}, "project2-data.golden"},
 
 		{"project 3 - reload ", []string{"--config=test/project3/corectl.yml ", connectToEngine, "reload"}, "project3-reload.golden"},
 		{"project 3 - fields", []string{"--config=test/project3/corectl.yml ", connectToEngine, "fields"}, "project3-fields.golden"},
-		{"err 2", []string{connectToEngine, "--app=nosuchapp.qvf", "eval", "count(numbers)", "by", "xyz"}, "err-2.golden"},
-		{"err 3", []string{connectToEngine, "--app=project1.qvf", "--object=nosuchobject", "data"}, "err-3.golden"},
+		{"err 2", []string{connectToEngine, "--app=nosuchapp.qvf --headers authorization=\"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0\"", "eval", "count(numbers)", "by", "xyz"}, "err-2.golden"},
+		{"err 3", []string{connectToEngine, "--app=project1.qvf --headers authorization=\"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0\"", "--object=nosuchobject", "data"}, "err-3.golden"},
 
 		// Project 4 has no JWT
 		{"err jwt", []string{connectToEngine, "apps"}, "err-jwt.golden"},

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -99,14 +99,14 @@ func TestCorectlGolden(t *testing.T) {
 		{"project 1 - reload without progress", []string{"--config=test/project1/corectl.yml", connectToEngine, "reload", "--silent"}, "project1-reload-silent.golden"},
 
 		// Project 2 has separate connections file
-		{"project 2 - reload with connections", []string{connectToEngine, "-a=project2.qvf", "reload", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json --headers authorization=\"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0\""}, "project2-reload.golden"},
+		{"project 2 - reload with connections", []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "reload", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, "project2-reload.golden"},
 		{"project 2 - fields ", []string{"--config=test/project2/corectl.yml ", connectToEngine, "fields"}, "project2-fields.golden"},
 		{"project 2 - data", []string{"--config=test/project2/corectl.yml ", connectToEngine, "--object", "my-hypercube-on-commandline", "data"}, "project2-data.golden"},
 
 		{"project 3 - reload ", []string{"--config=test/project3/corectl.yml ", connectToEngine, "reload"}, "project3-reload.golden"},
 		{"project 3 - fields", []string{"--config=test/project3/corectl.yml ", connectToEngine, "fields"}, "project3-fields.golden"},
-		{"err 2", []string{connectToEngine, "--app=nosuchapp.qvf --headers authorization=\"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0\"", "eval", "count(numbers)", "by", "xyz"}, "err-2.golden"},
-		{"err 3", []string{connectToEngine, "--app=project1.qvf --headers authorization=\"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0\"", "--object=nosuchobject", "data"}, "err-3.golden"},
+		{"err 2", []string{connectToEngine, "--app=nosuchapp.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "eval", "count(numbers)", "by", "xyz"}, "err-2.golden"},
+		{"err 3", []string{connectToEngine, "--app=project1.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "--object=nosuchobject", "data"}, "err-3.golden"},
 
 		// Project 4 has no JWT
 		{"err jwt", []string{connectToEngine, "apps"}, "err-jwt.golden"},
@@ -146,8 +146,8 @@ func TestCorectlContains(t *testing.T) {
 		args     []string
 		contains []string
 	}{
-		{"list apps", []string{connectToEngine, "apps"}, []string{"Id", "Name", "Last-Reloaded", "ReadOnly", "Title", "project2.qvf", "project1.qvf"}},
-		{"list apps json", []string{connectToEngine, "apps", "--json"}, []string{"\"id\": \"/apps/project2.qvf\","}},
+		{"list apps", []string{connectToEngine, "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "apps"}, []string{"Id", "Name", "Last-Reloaded", "ReadOnly", "Title", "project2.qvf", "project1.qvf"}},
+		{"list apps json", []string{connectToEngine, "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "apps", "--json"}, []string{"\"id\": \"/apps/project2.qvf\","}},
 		{"err 1", []string{"--engine=localhost:9999", "fields"}, []string{"Please check the --engine parameter or your config file", "Error details:  dial tcp"}},
 	}
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: qlikcore/engine:12.251.0
     ports:
       - 9076:9076
-    command: -S AcceptEULA=${ACCEPT_EULA}  -S DocumentDirectory=/apps -S EnableGrpcCustomConnectors=1 -S GrpcConnectorPlugins="testconnector,corectl-test-connector:50051"
+    command: -S AcceptEULA=${ACCEPT_EULA}  -S DocumentDirectory=/apps -S EnableGrpcCustomConnectors=1 -S ValidateJsonWebTokens=2 -S JsonWebTokenSecret=passw0rd -S GrpcConnectorPlugins="testconnector,corectl-test-connector:50051"
     volumes:
       - ./apps:/apps
       - ./data:/data

--- a/test/golden/err-jwt.golden
+++ b/test/golden/err-jwt.golden
@@ -1,2 +1,3 @@
 Could not connect to engine on localhost:9076.
+Please check the --engine parameter or your config file.
 Error details:  401 from ws server: websocket: bad handshake

--- a/test/golden/err-jwt.golden
+++ b/test/golden/err-jwt.golden
@@ -1,0 +1,2 @@
+Could not connect to engine on localhost:9076.
+Error details:  401 from ws server: websocket: bad handshake

--- a/test/golden/err-jwt.golden
+++ b/test/golden/err-jwt.golden
@@ -1,3 +1,0 @@
-Could not connect to engine on localhost:9076.
-Please check the --engine parameter or your config file.
-Error details:  401 from ws server: websocket: bad handshake

--- a/test/golden/help-1.golden
+++ b/test/golden/help-1.golden
@@ -25,11 +25,12 @@ Available Commands:
   version       Print the version of corectl
 
 Flags:
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-  -h, --help            help for corectl
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -h, --help                     help for corectl
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 
 Use "corectl [command] --help" for more information about a command.

--- a/test/golden/help-2.golden
+++ b/test/golden/help-2.golden
@@ -25,11 +25,12 @@ Available Commands:
   version       Print the version of corectl
 
 Flags:
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-  -h, --help            help for corectl
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -h, --help                     help for corectl
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information
 
 Use "corectl [command] --help" for more information about a command.

--- a/test/golden/help-3.golden
+++ b/test/golden/help-3.golden
@@ -11,8 +11,9 @@ Flags:
       --silent               Do not log reload progress
 
 Global Flags:
-  -a, --app string      App name including .qvf file ending. If no app is specified a session app is used instead.
-  -c, --config string   path/to/config.yml where parameters can be set instead of on the command line
-  -e, --engine string   URL to engine (default "localhost:9076")
-      --ttl string      Engine session time to live (default "30")
-  -v, --verbose         Logs extra information
+  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
+  -e, --engine string            URL to engine (default "localhost:9076")
+      --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --ttl string               Engine session time to live (default "30")
+  -v, --verbose                  Logs extra information

--- a/test/project1/corectl.yml
+++ b/test/project1/corectl.yml
@@ -9,3 +9,5 @@ connections:
       host: corectl-test-connector
 objects:
   - ./object-*.json
+headers:
+  authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0" #generated at jwt.io with the password passw0rd

--- a/test/project2/corectl.yml
+++ b/test/project2/corectl.yml
@@ -1,3 +1,5 @@
 engine: localhost:9076
 app: project2.qvf
 script: ./script.qvs
+headers:
+  authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0" #generated at jwt.io with the password passw0rd

--- a/test/project3/corectl.yml
+++ b/test/project3/corectl.yml
@@ -3,3 +3,5 @@ script: ./script.qvs
 connections:
   testdata:
     path: /data
+headers:
+  authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0" #generated at jwt.io with the password passw0rd

--- a/test/project4/corectl.yml
+++ b/test/project4/corectl.yml
@@ -1,0 +1,1 @@
+engine: localhost:9076

--- a/test/project4/corectl.yml
+++ b/test/project4/corectl.yml
@@ -1,1 +1,0 @@
-engine: localhost:9076


### PR DESCRIPTION
This PR adds header support for corectl.

The headers will be used both when connecting with WS and over REST to the Engine.

The headers can both be specified in the config file like
```
headers:
  authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0" 
```

and on the command line like this `corectl --headers authorization="Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0"`

If you specify your headers both in your command line and the config file, the ones from the command line will be used. (They will not both be used, only one source will ever be used)


Closes #10 