### PR TITLE
Added: getConnections, getConnection, removeApp, removeConnection.

### DIFF
--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -24,7 +24,7 @@ corectl [flags]
 * [corectl eval](corectl_eval.md)	 - Evaluates a list of measures and dimensions
 * [corectl get](corectl_get.md)	 - Lists one or several resources
 * [corectl reload](corectl_reload.md)	 - Reloads the app.
-* [corectl remove](corectl_remove.md)	 - Remove one or mores generic entities (dimensions, measures, objects) in the app
+* [corectl remove](corectl_remove.md)	 - Remove entities (connections, dimensions, measures, objects) in the app or the app itself
 * [corectl set](corectl_set.md)	 - Sets one or several resources
 * [corectl version](corectl_version.md)	 - Print the version of corectl
 

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -15,7 +15,7 @@ corectl build [flags]
 ### Options
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --connections string       path/to/connections.yml that contains connections that are used in the reload. Note that when specifying connections in the config file they are specified inline, not as a file reference!
       --dimensions string        A list of generic dimension json paths

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -20,7 +20,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
 ### Options
 
 ```
-  -a, --app string           App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string           App name, if no app is specified a session app is used instead.
       --catwalk-url string   Url to an instance of catwalk, if not provided the qlik one will be used. (default "https://catwalk.core.qlik.com")
   -c, --config string        path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string        URL to engine (default "localhost:9076")

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -22,7 +22,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
 ### Options
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_get.md
+++ b/docs/corectl_get.md
@@ -27,6 +27,8 @@ Lists one or several resources
 * [corectl](corectl.md)	 - 
 * [corectl get apps](corectl_get_apps.md)	 - Prints a list of all apps available in the current engine
 * [corectl get assoc](corectl_get_assoc.md)	 - Print table associations summary
+* [corectl get connection](corectl_get_connection.md)	 - Shows the content of a specific connector
+* [corectl get connections](corectl_get_connections.md)	 - Prints a list of all connections in the current app
 * [corectl get dimension](corectl_get_dimension.md)	 - Shows content of an generic dimension
 * [corectl get dimensions](corectl_get_dimensions.md)	 - Prints a list of all generic dimensions in the current app
 * [corectl get field](corectl_get_field.md)	 - Shows content of a field

--- a/docs/corectl_get.md
+++ b/docs/corectl_get.md
@@ -28,7 +28,7 @@ Lists one or several resources
 * [corectl get apps](corectl_get_apps.md)	 - Prints a list of all apps available in the current engine
 * [corectl get assoc](corectl_get_assoc.md)	 - Print table associations summary
 * [corectl get connection](corectl_get_connection.md)	 - Shows the properties for a specific connection
-* [corectl get connections](corectl_get_connections.md)	 - Prints a list of all connections in the current app
+* [corectl get connections](corectl_get_connections.md)	 - Prints a list of all connections in the specified app
 * [corectl get dimension](corectl_get_dimension.md)	 - Shows content of an generic dimension
 * [corectl get dimensions](corectl_get_dimensions.md)	 - Prints a list of all generic dimensions in the current app
 * [corectl get field](corectl_get_field.md)	 - Shows content of a field

--- a/docs/corectl_get.md
+++ b/docs/corectl_get.md
@@ -27,7 +27,7 @@ Lists one or several resources
 * [corectl](corectl.md)	 - 
 * [corectl get apps](corectl_get_apps.md)	 - Prints a list of all apps available in the current engine
 * [corectl get assoc](corectl_get_assoc.md)	 - Print table associations summary
-* [corectl get connection](corectl_get_connection.md)	 - Shows the content of a specific connector
+* [corectl get connection](corectl_get_connection.md)	 - Shows the properties for a specific connection
 * [corectl get connections](corectl_get_connections.md)	 - Prints a list of all connections in the current app
 * [corectl get dimension](corectl_get_dimension.md)	 - Shows content of an generic dimension
 * [corectl get dimensions](corectl_get_dimensions.md)	 - Prints a list of all generic dimensions in the current app

--- a/docs/corectl_get_assoc.md
+++ b/docs/corectl_get_assoc.md
@@ -13,7 +13,7 @@ corectl get assoc [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for assoc
 ```
 

--- a/docs/corectl_get_connection.md
+++ b/docs/corectl_get_connection.md
@@ -1,21 +1,26 @@
-## corectl remove objects
+## corectl get connection
 
-Removes the specified generic objects in the current app
+Shows the content of a specific connector
 
 ### Synopsis
 
-Removes the specified generic objects in the current app. Example: corectl remove objects ID-1 ID-2
+Shows the content of a specific connector
 
 ```
-corectl remove objects <object-id>... [flags]
+corectl get connection [flags]
+```
+
+### Examples
+
+```
+corectl get connection CONNECTION-ID
 ```
 
 ### Options
 
 ```
   -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
-  -h, --help         help for objects
-      --no-save      Do not save the app
+  -h, --help         help for connection
 ```
 
 ### Options inherited from parent commands
@@ -30,5 +35,5 @@ corectl remove objects <object-id>... [flags]
 
 ### SEE ALSO
 
-* [corectl remove](corectl_remove.md)	 - Remove entities (connections, dimensions, measures, objects) in the app or the app itself
+* [corectl get](corectl_get.md)	 - Lists one or several resources
 

--- a/docs/corectl_get_connection.md
+++ b/docs/corectl_get_connection.md
@@ -19,7 +19,7 @@ corectl get connection CONNECTION-ID
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for connection
 ```
 

--- a/docs/corectl_get_connection.md
+++ b/docs/corectl_get_connection.md
@@ -1,10 +1,10 @@
 ## corectl get connection
 
-Shows the content of a specific connector
+Shows the properties for a specific connection
 
 ### Synopsis
 
-Shows the content of a specific connector
+Shows the properties for a specific connection
 
 ```
 corectl get connection [flags]

--- a/docs/corectl_get_connections.md
+++ b/docs/corectl_get_connections.md
@@ -1,10 +1,10 @@
 ## corectl get connections
 
-Prints a list of all connections in the current app
+Prints a list of all connections in the specified app
 
 ### Synopsis
 
-Prints a list of all connections in the current app
+Prints a list of all connections in the specified app
 
 ```
 corectl get connections [flags]
@@ -19,7 +19,7 @@ corectl get connections
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for connections
       --json         Prints the information in json format
 ```

--- a/docs/corectl_get_connections.md
+++ b/docs/corectl_get_connections.md
@@ -1,21 +1,27 @@
-## corectl remove objects
+## corectl get connections
 
-Removes the specified generic objects in the current app
+Prints a list of all connections in the current app
 
 ### Synopsis
 
-Removes the specified generic objects in the current app. Example: corectl remove objects ID-1 ID-2
+Prints a list of all connections in the current app
 
 ```
-corectl remove objects <object-id>... [flags]
+corectl get connections [flags]
+```
+
+### Examples
+
+```
+corectl get connections
 ```
 
 ### Options
 
 ```
   -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
-  -h, --help         help for objects
-      --no-save      Do not save the app
+  -h, --help         help for connections
+      --json         Prints the information in json format
 ```
 
 ### Options inherited from parent commands
@@ -30,5 +36,5 @@ corectl remove objects <object-id>... [flags]
 
 ### SEE ALSO
 
-* [corectl remove](corectl_remove.md)	 - Remove entities (connections, dimensions, measures, objects) in the app or the app itself
+* [corectl get](corectl_get.md)	 - Lists one or several resources
 

--- a/docs/corectl_get_dimension.md
+++ b/docs/corectl_get_dimension.md
@@ -13,7 +13,7 @@ corectl get dimension <dimension-id> [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for dimension
 ```
 

--- a/docs/corectl_get_dimension_layout.md
+++ b/docs/corectl_get_dimension_layout.md
@@ -19,7 +19,7 @@ corectl get dimension layout <dimension-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_get_dimension_properties.md
+++ b/docs/corectl_get_dimension_properties.md
@@ -19,7 +19,7 @@ corectl get dimension properties <dimension-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_get_dimensions.md
+++ b/docs/corectl_get_dimensions.md
@@ -13,7 +13,7 @@ corectl get dimensions [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for dimensions
       --json         Prints the information in json format
 ```

--- a/docs/corectl_get_field.md
+++ b/docs/corectl_get_field.md
@@ -13,7 +13,7 @@ corectl get field <field name> [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for field
 ```
 

--- a/docs/corectl_get_fields.md
+++ b/docs/corectl_get_fields.md
@@ -13,7 +13,7 @@ corectl get fields [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for fields
 ```
 

--- a/docs/corectl_get_keys.md
+++ b/docs/corectl_get_keys.md
@@ -13,7 +13,7 @@ corectl get keys [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for keys
 ```
 

--- a/docs/corectl_get_measure.md
+++ b/docs/corectl_get_measure.md
@@ -13,7 +13,7 @@ corectl get measure <measure-id> [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for measure
 ```
 

--- a/docs/corectl_get_measure_layout.md
+++ b/docs/corectl_get_measure_layout.md
@@ -19,7 +19,7 @@ corectl get measure layout <measure-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_get_measure_properties.md
+++ b/docs/corectl_get_measure_properties.md
@@ -19,7 +19,7 @@ corectl get measure properties <measure-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_get_measures.md
+++ b/docs/corectl_get_measures.md
@@ -13,7 +13,7 @@ corectl get measures [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for measures
       --json         Prints the information in json format
 ```

--- a/docs/corectl_get_meta.md
+++ b/docs/corectl_get_meta.md
@@ -13,7 +13,7 @@ corectl get meta [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for meta
 ```
 

--- a/docs/corectl_get_object.md
+++ b/docs/corectl_get_object.md
@@ -13,7 +13,7 @@ corectl get object <object-id> [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for object
 ```
 

--- a/docs/corectl_get_object_data.md
+++ b/docs/corectl_get_object_data.md
@@ -19,7 +19,7 @@ corectl get object data <object-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_get_object_layout.md
+++ b/docs/corectl_get_object_layout.md
@@ -19,7 +19,7 @@ corectl get object layout <object-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_get_object_properties.md
+++ b/docs/corectl_get_object_properties.md
@@ -19,7 +19,7 @@ corectl get object properties <object-id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_get_objects.md
+++ b/docs/corectl_get_objects.md
@@ -13,7 +13,7 @@ corectl get objects [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for objects
       --json         Prints the information in json format
 ```

--- a/docs/corectl_get_script.md
+++ b/docs/corectl_get_script.md
@@ -13,7 +13,7 @@ corectl get script [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for script
 ```
 

--- a/docs/corectl_get_status.md
+++ b/docs/corectl_get_status.md
@@ -13,7 +13,7 @@ corectl get status [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for status
 ```
 

--- a/docs/corectl_get_tables.md
+++ b/docs/corectl_get_tables.md
@@ -13,7 +13,7 @@ corectl get tables [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for tables
 ```
 

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -13,7 +13,7 @@ corectl reload [flags]
 ### Options
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_remove.md
+++ b/docs/corectl_remove.md
@@ -1,20 +1,18 @@
 ## corectl remove
 
-Remove one or mores generic entities (dimensions, measures, objects) in the app
+Remove entities (connections, dimensions, measures, objects) in the app or the app itself
 
 ### Synopsis
 
-Remove one or mores generic entities (dimensions, measures, objects) in the app
+Remove one or mores generic entities (connections, dimensions, measures, objects) in the app
 
 ### Options
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
   -h, --help                     help for remove
-      --no-save                  Do not save the app
       --ttl string               Engine session time to live in seconds (default "30")
 ```
 
@@ -27,6 +25,8 @@ Remove one or mores generic entities (dimensions, measures, objects) in the app
 ### SEE ALSO
 
 * [corectl](corectl.md)	 - 
+* [corectl remove app](corectl_remove_app.md)	 - removes the specified app.
+* [corectl remove connection](corectl_remove_connection.md)	 - removes the specified connection.
 * [corectl remove dimensions](corectl_remove_dimensions.md)	 - Removes the specified generic dimensions in the current app
 * [corectl remove measures](corectl_remove_measures.md)	 - Removes the specified generic measures in the current app
 * [corectl remove objects](corectl_remove_objects.md)	 - Removes the specified generic objects in the current app

--- a/docs/corectl_remove_app.md
+++ b/docs/corectl_remove_app.md
@@ -1,21 +1,25 @@
-## corectl remove objects
+## corectl remove app
 
-Removes the specified generic objects in the current app
+removes the specified app.
 
 ### Synopsis
 
-Removes the specified generic objects in the current app. Example: corectl remove objects ID-1 ID-2
+removes the specified app.
 
 ```
-corectl remove objects <object-id>... [flags]
+corectl remove app <app-id> [flags]
+```
+
+### Examples
+
+```
+corectl remove app APP-ID
 ```
 
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
-  -h, --help         help for objects
-      --no-save      Do not save the app
+  -h, --help   help for app
 ```
 
 ### Options inherited from parent commands

--- a/docs/corectl_remove_connection.md
+++ b/docs/corectl_remove_connection.md
@@ -19,7 +19,7 @@ corectl remove connection CONNECTION-ID
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for connection
       --no-save      Do not save the app
 ```

--- a/docs/corectl_remove_connection.md
+++ b/docs/corectl_remove_connection.md
@@ -1,20 +1,26 @@
-## corectl remove objects
+## corectl remove connection
 
-Removes the specified generic objects in the current app
+removes the specified connection.
 
 ### Synopsis
 
-Removes the specified generic objects in the current app. Example: corectl remove objects ID-1 ID-2
+removes the specified connection.
 
 ```
-corectl remove objects <object-id>... [flags]
+corectl remove connection <connection-id> [flags]
+```
+
+### Examples
+
+```
+corectl remove connection CONNECTION-ID
 ```
 
 ### Options
 
 ```
   -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
-  -h, --help         help for objects
+  -h, --help         help for connection
       --no-save      Do not save the app
 ```
 

--- a/docs/corectl_remove_dimensions.md
+++ b/docs/corectl_remove_dimensions.md
@@ -13,7 +13,7 @@ corectl remove dimensions <dimension-id>... [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for dimensions
       --no-save      Do not save the app
 ```

--- a/docs/corectl_remove_dimensions.md
+++ b/docs/corectl_remove_dimensions.md
@@ -13,22 +13,22 @@ corectl remove dimensions <dimension-id>... [flags]
 ### Options
 
 ```
-  -h, --help   help for dimensions
+  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -h, --help         help for dimensions
+      --no-save      Do not save the app
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-      --no-save                  Do not save the app
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO
 
-* [corectl remove](corectl_remove.md)	 - Remove one or mores generic entities (dimensions, measures, objects) in the app
+* [corectl remove](corectl_remove.md)	 - Remove entities (connections, dimensions, measures, objects) in the app or the app itself
 

--- a/docs/corectl_remove_measures.md
+++ b/docs/corectl_remove_measures.md
@@ -13,7 +13,7 @@ corectl remove measures <measure-id>... [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for measures
       --no-save      Do not save the app
 ```

--- a/docs/corectl_remove_measures.md
+++ b/docs/corectl_remove_measures.md
@@ -13,22 +13,22 @@ corectl remove measures <measure-id>... [flags]
 ### Options
 
 ```
-  -h, --help   help for measures
+  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -h, --help         help for measures
+      --no-save      Do not save the app
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-      --no-save                  Do not save the app
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```
 
 ### SEE ALSO
 
-* [corectl remove](corectl_remove.md)	 - Remove one or mores generic entities (dimensions, measures, objects) in the app
+* [corectl remove](corectl_remove.md)	 - Remove entities (connections, dimensions, measures, objects) in the app or the app itself
 

--- a/docs/corectl_remove_objects.md
+++ b/docs/corectl_remove_objects.md
@@ -13,7 +13,7 @@ corectl remove objects <object-id>... [flags]
 ### Options
 
 ```
-  -a, --app string   App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string   App name, if no app is specified a session app is used instead.
   -h, --help         help for objects
       --no-save      Do not save the app
 ```

--- a/docs/corectl_set.md
+++ b/docs/corectl_set.md
@@ -9,7 +9,7 @@ Sets one or several resources
 ### Options
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_set_all.md
+++ b/docs/corectl_set_all.md
@@ -24,7 +24,7 @@ corectl set all [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_set_connections.md
+++ b/docs/corectl_set_connections.md
@@ -20,7 +20,7 @@ corectl set connections <path-to-connections-file.yml> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_set_dimensions.md
+++ b/docs/corectl_set_dimensions.md
@@ -19,7 +19,7 @@ corectl set dimensions <glob-pattern-path-to-dimensions-files.json> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_set_measures.md
+++ b/docs/corectl_set_measures.md
@@ -19,7 +19,7 @@ corectl set measures <glob-pattern-path-to-measures-files.json> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_set_objects.md
+++ b/docs/corectl_set_objects.md
@@ -19,7 +19,7 @@ corectl set objects <glob-pattern-path-to-objects-files.json [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/docs/corectl_set_script.md
+++ b/docs/corectl_set_script.md
@@ -19,7 +19,7 @@ corectl set script <path-to-script-file.yml> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])

--- a/internal/connections.go
+++ b/internal/connections.go
@@ -74,7 +74,10 @@ func SetupConnections(ctx context.Context, doc *enigma.Doc, separateConnectionsF
 			err = doc.ModifyConnection(ctx, existingConnectionID, connection, true)
 		} else {
 			LogVerbose("Creating new connection: " + fmt.Sprint(connection))
-			_, err = doc.CreateConnection(ctx, connection)
+			id, err := doc.CreateConnection(ctx, connection)
+			if err == nil {
+				fmt.Println("New connection created with id: ", id)
+			}
 		}
 
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -192,8 +192,8 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 	getConnectionsCmd = &cobra.Command{
 		Use:     "connections",
-		Short:   "Prints a list of all connections in the current app",
-		Long:    "Prints a list of all connections in the current app",
+		Short:   "Prints a list of all connections in the specified app",
+		Long:    "Prints a list of all connections in the specified app",
 		Example: "corectl get connections",
 
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
@@ -987,7 +987,7 @@ func init() {
 	}
 
 	for _, command := range []*cobra.Command{buildCmd, catwalkCmd, evalCmd, getAssociationsCmd, getConnectionsCmd, getConnectionCmd, getDimensionsCmd, getDimensionCmd, getFieldsCmd, getKeysCmd, getFieldCmd, getMeasuresCmd, getMeasureCmd, getMetaCmd, getObjectsCmd, getObjectCmd, getScriptCmd, getStatusCmd, getTablesCmd, reloadCmd, removeConnectionCmd, removeDimensionsCmd, removeMeasuresCmd, removeObjectsCmd, setCmd} {
-		command.PersistentFlags().StringP("app", "a", "", "App name including .qvf file ending. If no app is specified a session app is used instead.")
+		command.PersistentFlags().StringP("app", "a", "", "App name, if no app is specified a session app is used instead.")
 	}
 
 	for _, command := range []*cobra.Command{buildCmd, setAllCmd, setConnectionsCmd} {

--- a/main.go
+++ b/main.go
@@ -190,6 +190,54 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 		},
 	}
 
+	getConnectionsCmd = &cobra.Command{
+		Use:     "connections",
+		Short:   "Prints a list of all connections in the current app",
+		Long:    "Prints a list of all connections in the current app",
+		Example: "corectl get connections",
+
+		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
+			getCmd.PersistentPreRun(getCmd, args)
+			viper.BindPFlag("app", ccmd.PersistentFlags().Lookup("app"))
+			viper.BindPFlag("json", ccmd.PersistentFlags().Lookup("json"))
+		},
+
+		Run: func(ccmd *cobra.Command, args []string) {
+			state := internal.PrepareEngineState(rootCtx, viper.GetString("engine"), viper.GetString("app"), viper.GetString("ttl"), headers, true)
+			connections, err := state.Doc.GetConnections(rootCtx)
+			if err != nil {
+				internal.FatalError(err)
+			}
+			printer.PrintConnections(connections, viper.GetBool("json"))
+		},
+	}
+
+	getConnectionCmd = &cobra.Command{
+		Use:     "connection",
+		Short:   "Shows the content of a specific connector",
+		Long:    "Shows the content of a specific connector",
+		Example: "corectl get connection CONNECTION-ID",
+
+		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
+			getCmd.PersistentPreRun(getCmd, args)
+			viper.BindPFlag("app", ccmd.PersistentFlags().Lookup("app"))
+		},
+
+		Run: func(ccmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				fmt.Println("Expected a connection name as parameter")
+				ccmd.Usage()
+				os.Exit(1)
+			}
+			state := internal.PrepareEngineState(rootCtx, viper.GetString("engine"), viper.GetString("app"), viper.GetString("ttl"), headers, true)
+			connection, err := state.Doc.GetConnection(rootCtx, args[0])
+			if err != nil {
+				internal.FatalError(err)
+			}
+			printer.PrintConnection(connection)
+		},
+	}
+
 	getDimensionsCmd = &cobra.Command{
 		Use:   "dimensions",
 		Short: "Prints a list of all generic dimensions in the current app",
@@ -557,21 +605,60 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 	removeCmd = &cobra.Command{
 		Use:   "remove",
-		Short: "Remove one or mores generic entities (dimensions, measures, objects) in the app",
-		Long:  "Remove one or mores generic entities (dimensions, measures, objects) in the app",
+		Short: "Remove entities (connections, dimensions, measures, objects) in the app or the app itself",
+		Long:  "Remove one or mores generic entities (connections, dimensions, measures, objects) in the app",
 
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
 			corectlCommand.PersistentPreRun(corectlCommand, args)
-			viper.BindPFlag("app", ccmd.PersistentFlags().Lookup("app"))
 			viper.BindPFlag("engine", ccmd.PersistentFlags().Lookup("engine"))
 			viper.BindPFlag("ttl", ccmd.PersistentFlags().Lookup("ttl"))
-			viper.BindPFlag("no-save", ccmd.PersistentFlags().Lookup("no-save"))
+		},
+	}
 
-			if len(args) < 1 {
-				fmt.Println("Expected atleast one entity id specify what entity to remove from the app")
+	removeAppCmd = &cobra.Command{
+		Use:     "app <app-id>",
+		Short:   "removes the specified app.",
+		Long:    `removes the specified app.`,
+		Example: "corectl remove app APP-ID",
+		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
+			removeCmd.PersistentPreRun(removeCmd, args)
+		},
+		Run: func(ccmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				fmt.Println("Expected an identifier of the app to delete.")
 				ccmd.Usage()
 				os.Exit(1)
 			}
+			internal.DeleteApp(rootCtx, viper.GetString("engine"), args[0], viper.GetString("ttl"), headers)
+		},
+	}
+
+	removeConnectionCmd = &cobra.Command{
+		Use:     "connection <connection-id>",
+		Short:   "removes the specified connection.",
+		Long:    `removes the specified connection.`,
+		Example: "corectl remove connection CONNECTION-ID",
+		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
+			removeCmd.PersistentPreRun(removeCmd, args)
+			viper.BindPFlag("app", ccmd.PersistentFlags().Lookup("app"))
+			viper.BindPFlag("no-save", ccmd.PersistentFlags().Lookup("no-save"))
+		},
+		Run: func(ccmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				fmt.Println("Expected an identifier of the connection to delete.")
+				ccmd.Usage()
+				os.Exit(1)
+			}
+
+			state := internal.PrepareEngineState(rootCtx, viper.GetString("engine"), viper.GetString("app"), viper.GetString("ttl"), headers, true)
+			err := state.Doc.DeleteConnection(rootCtx, args[0])
+			if err != nil {
+				internal.FatalError("Failed to remove connection", args[0])
+			}
+			if state.AppID != "" && !viper.GetBool("no-save") {
+				internal.Save(rootCtx, state.Doc, state.AppID)
+			}
+
 		},
 	}
 
@@ -582,9 +669,16 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
 			removeCmd.PersistentPreRun(removeCmd, args)
+			viper.BindPFlag("app", ccmd.PersistentFlags().Lookup("app"))
+			viper.BindPFlag("no-save", ccmd.PersistentFlags().Lookup("no-save"))
 		},
 
 		Run: func(ccmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				fmt.Println("Expected atleast one entity id specify what entity to remove from the app")
+				ccmd.Usage()
+				os.Exit(1)
+			}
 			state := internal.PrepareEngineState(rootCtx, viper.GetString("engine"), viper.GetString("app"), viper.GetString("ttl"), headers, false)
 			for _, entity := range args {
 				destroyed, err := state.Doc.DestroyDimension(rootCtx, entity)
@@ -607,9 +701,16 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
 			removeCmd.PersistentPreRun(removeCmd, args)
+			viper.BindPFlag("app", ccmd.PersistentFlags().Lookup("app"))
+			viper.BindPFlag("no-save", ccmd.PersistentFlags().Lookup("no-save"))
 		},
 
 		Run: func(ccmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				fmt.Println("Expected atleast one entity id specify what entity to remove from the app")
+				ccmd.Usage()
+				os.Exit(1)
+			}
 			state := internal.PrepareEngineState(rootCtx, viper.GetString("engine"), viper.GetString("app"), viper.GetString("ttl"), headers, false)
 			for _, entity := range args {
 				destroyed, err := state.Doc.DestroyMeasure(rootCtx, entity)
@@ -632,9 +733,16 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
 			removeCmd.PersistentPreRun(removeCmd, args)
+			viper.BindPFlag("app", ccmd.PersistentFlags().Lookup("app"))
+			viper.BindPFlag("no-save", ccmd.PersistentFlags().Lookup("no-save"))
 		},
 
 		Run: func(ccmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				fmt.Println("Expected atleast one entity id specify what entity to remove from the app")
+				ccmd.Usage()
+				os.Exit(1)
+			}
 			state := internal.PrepareEngineState(rootCtx, viper.GetString("engine"), viper.GetString("app"), viper.GetString("ttl"), headers, false)
 			for _, entity := range args {
 				destroyed, err := state.Doc.DestroyObject(rootCtx, entity)
@@ -878,7 +986,7 @@ func init() {
 		command.PersistentFlags().StringToStringVar(&headersMap, "headers", nil, "Headers to use when connecting to qix engine")
 	}
 
-	for _, command := range []*cobra.Command{buildCmd, catwalkCmd, evalCmd, getAssociationsCmd, getDimensionsCmd, getDimensionCmd, getFieldsCmd, getKeysCmd, getFieldCmd, getMeasuresCmd, getMeasureCmd, getMetaCmd, getObjectsCmd, getObjectCmd, getScriptCmd, getStatusCmd, getTablesCmd, reloadCmd, removeCmd, setCmd} {
+	for _, command := range []*cobra.Command{buildCmd, catwalkCmd, evalCmd, getAssociationsCmd, getConnectionsCmd, getConnectionCmd, getDimensionsCmd, getDimensionCmd, getFieldsCmd, getKeysCmd, getFieldCmd, getMeasuresCmd, getMeasureCmd, getMetaCmd, getObjectsCmd, getObjectCmd, getScriptCmd, getStatusCmd, getTablesCmd, reloadCmd, removeConnectionCmd, removeDimensionsCmd, removeMeasuresCmd, removeObjectsCmd, setCmd} {
 		command.PersistentFlags().StringP("app", "a", "", "App name including .qvf file ending. If no app is specified a session app is used instead.")
 	}
 
@@ -906,7 +1014,7 @@ func init() {
 		command.PersistentFlags().Bool("silent", false, "Do not log reload progress")
 	}
 
-	for _, command := range []*cobra.Command{reloadCmd, removeCmd, setCmd} {
+	for _, command := range []*cobra.Command{reloadCmd, removeConnectionCmd, removeDimensionsCmd, removeMeasuresCmd, removeObjectsCmd, setCmd} {
 		command.PersistentFlags().Bool("no-save", false, "Do not save the app")
 	}
 
@@ -915,7 +1023,7 @@ func init() {
 		command.PersistentFlags().String("script", "", "path/to/reload-script.qvs that contains a qlik reload script. If omitted the last specified reload script for the current app is reloaded")
 	}
 
-	for _, command := range []*cobra.Command{getAppsCmd, getDimensionsCmd, getMeasuresCmd, getObjectsCmd} {
+	for _, command := range []*cobra.Command{getAppsCmd, getConnectionsCmd, getDimensionsCmd, getMeasuresCmd, getObjectsCmd} {
 		command.PersistentFlags().Bool("json", false, "Prints the information in json format")
 	}
 
@@ -934,6 +1042,8 @@ func init() {
 
 	getCmd.AddCommand(getAppsCmd)
 	getCmd.AddCommand(getAssociationsCmd)
+	getCmd.AddCommand(getConnectionsCmd)
+	getCmd.AddCommand(getConnectionCmd)
 	getCmd.AddCommand(getDimensionCmd)
 	getCmd.AddCommand(getDimensionsCmd)
 	getCmd.AddCommand(getFieldCmd)
@@ -958,6 +1068,8 @@ func init() {
 	getMeasureCmd.AddCommand(getMeasurePropertiesCmd)
 	getMeasureCmd.AddCommand(getMeasureLayoutCmd)
 
+	removeCmd.AddCommand(removeAppCmd)
+	removeCmd.AddCommand(removeConnectionCmd)
 	removeCmd.AddCommand(removeDimensionsCmd)
 	removeCmd.AddCommand(removeMeasuresCmd)
 	removeCmd.AddCommand(removeObjectsCmd)

--- a/main.go
+++ b/main.go
@@ -214,8 +214,8 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 	getConnectionCmd = &cobra.Command{
 		Use:     "connection",
-		Short:   "Shows the content of a specific connector",
-		Long:    "Shows the content of a specific connector",
+		Short:   "Shows the properties for a specific connection",
+		Long:    "Shows the properties for a specific connection",
 		Example: "corectl get connection CONNECTION-ID",
 
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
@@ -675,7 +675,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			if len(args) < 1 {
-				fmt.Println("Expected atleast one entity id specify what entity to remove from the app")
+				fmt.Println("Expected atleast one dimension-id specify what dimension to remove from the app")
 				ccmd.Usage()
 				os.Exit(1)
 			}
@@ -707,7 +707,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			if len(args) < 1 {
-				fmt.Println("Expected atleast one entity id specify what entity to remove from the app")
+				fmt.Println("Expected atleast one measure-id specify what measure to remove from the app")
 				ccmd.Usage()
 				os.Exit(1)
 			}
@@ -739,7 +739,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"`,
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			if len(args) < 1 {
-				fmt.Println("Expected atleast one entity id specify what entity to remove from the app")
+				fmt.Println("Expected atleast one object-id specify what object to remove from the app")
 				ccmd.Usage()
 				os.Exit(1)
 			}

--- a/printer/connections.go
+++ b/printer/connections.go
@@ -1,0 +1,37 @@
+package printer
+
+import (
+	"encoding/json"
+	"fmt"
+
+	tm "github.com/buger/goterm"
+	"github.com/qlik-oss/corectl/internal"
+	enigma "github.com/qlik-oss/enigma-go"
+)
+
+// PrintConnections prints a list of connections to standard out
+func PrintConnections(connections []*enigma.Connection, printAsJSON bool) {
+	if printAsJSON {
+		jsonPrinter(connections)
+	} else {
+		connectionsTable := tm.NewTable(0, 10, 3, ' ', 0)
+		fmt.Fprintf(connectionsTable, "Id\tName\n")
+		for _, connection := range connections {
+			fmt.Fprintf(connectionsTable, "%s\t%s\n", connection.Id, connection.Name)
+		}
+		fmt.Print(connectionsTable)
+	}
+}
+
+// PrintConnection prints a connection to standard out
+func PrintConnection(connection *enigma.Connection) {
+	jsonPrinter(connection)
+}
+
+func jsonPrinter(v interface{}) {
+	buffer, err := json.Marshal(v)
+	if err != nil {
+		internal.FatalError(err)
+	}
+	fmt.Println(prettyJSON(buffer))
+}

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -23,6 +23,7 @@ import (
 var update = flag.Bool("update", false, "update golden files")
 
 var engineIP = flag.String("engineIP", "localhost:9076", "dir of package containing embedded files")
+var connectToEngine = "--engine=" + *engineIP
 
 func getBinaryName() string {
 	if runtime.GOOS == "windows" {
@@ -80,13 +81,12 @@ func (tf *testFile) load() string {
 }
 
 func TestConnections(t *testing.T) {
-	cmd := exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "build", "--connections=test/project2/connections.yml"}...)
+	cmd := exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "build", "--connections=test/project2/connections.yml"}...)
 	cmd.Run()
-	cmd = exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "get", "connections", "--json"}...)
+	cmd = exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "get", "connections", "--json"}...)
 	output, _ := cmd.CombinedOutput()
 
 	//verify that the connection was created
-	fmt.Println(string(output))
 	var connections []*enigma.Connection
 	err := json.Unmarshal(output, &connections)
 	assert.NoError(t, err)
@@ -94,21 +94,20 @@ func TestConnections(t *testing.T) {
 	assert.NotNil(t, connections[0].Id)
 
 	//verify that removing the connection works
-	cmd = exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "remove", "connection", connections[0].Id}...)
+	cmd = exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "remove", "connection", connections[0].Id}...)
 	output, _ = cmd.CombinedOutput()
 	assert.Equal(t, "Saving...Done\n\n", string(output))
 
 	//verify that there is no connections in the app anymore.
-	cmd = exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "get", "connections", "--json"}...)
+	cmd = exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "get", "connections", "--json"}...)
 	output, _ = cmd.CombinedOutput()
 	assert.Equal(t, "[]\n", string(output))
 
 	//remove the app as clean-up (Otherwise we might share sessions when we use that app again.)
-	_ = exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "remove", "app", "project1.qvf"}...)
+	_ = exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "remove", "app", "project1.qvf"}...)
 }
 
 func TestCorectl(t *testing.T) {
-	connectToEngine := "--engine=" + *engineIP
 	tests := []struct {
 		name     string
 		args     []string

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -86,6 +86,7 @@ func TestConnections(t *testing.T) {
 	output, _ := cmd.CombinedOutput()
 
 	//verify that the connection was created
+	fmt.Println(string(output))
 	var connections []*enigma.Connection
 	err := json.Unmarshal(output, &connections)
 	assert.NoError(t, err)

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -80,10 +80,9 @@ func (tf *testFile) load() string {
 }
 
 func TestConnections(t *testing.T) {
-	connectToEngine := "--engine=" + *engineIP
-	cmd := exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "build", "--connections=test/project2/connections.yml"}...)
+	cmd := exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "build", "--connections=test/project2/connections.yml"}...)
 	cmd.Run()
-	cmd = exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "get", "connections", "--json"}...)
+	cmd = exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "get", "connections", "--json"}...)
 	output, _ := cmd.CombinedOutput()
 
 	//verify that the connection was created
@@ -94,17 +93,17 @@ func TestConnections(t *testing.T) {
 	assert.NotNil(t, connections[0].Id)
 
 	//verify that removing the connection works
-	cmd = exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "remove", "connection", connections[0].Id}...)
+	cmd = exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "remove", "connection", connections[0].Id}...)
 	output, _ = cmd.CombinedOutput()
 	assert.Equal(t, "Saving...Done\n\n", string(output))
 
 	//verify that there is no connections in the app anymore.
-	cmd = exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "get", "connections", "--json"}...)
+	cmd = exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "get", "connections", "--json"}...)
 	output, _ = cmd.CombinedOutput()
 	assert.Equal(t, "[]\n", string(output))
 
 	//remove the app as clean-up (Otherwise we might share sessions when we use that app again.)
-	_ = exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "remove", "app", "project1.qvf"}...)
+	_ = exec.Command(binaryPath, []string{"--config=test/project2/corectl.yml", "remove", "app", "project1.qvf"}...)
 }
 
 func TestCorectl(t *testing.T) {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -3,19 +3,21 @@
 package test
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
 
-	"reflect"
-
 	"github.com/kr/pretty"
+	enigma "github.com/qlik-oss/enigma-go"
+	"github.com/stretchr/testify/assert"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -77,89 +79,82 @@ func (tf *testFile) load() string {
 	return string(content)
 }
 
-func TestCorectlGolden(t *testing.T) {
+func TestConnections(t *testing.T) {
 	connectToEngine := "--engine=" + *engineIP
-	tests := []struct {
-		name   string
-		args   []string
-		golden string
-	}{
-		{"help 1", []string{""}, "help-1.golden"},
-		{"help 2", []string{"help"}, "help-2.golden"},
-		{"help 3", []string{"help", "build"}, "help-3.golden"},
-		{"project 1 - build", []string{"--config=test/project1/corectl.yml", connectToEngine, "build"}, "project1-build.golden"},
-		{"project 1 - get tables", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "tables"}, "project1-tables.golden"},
-		{"project 1 - get assoc", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "assoc"}, "project1-assoc.golden"},
-		{"project 1 - get fields", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "fields"}, "project1-fields.golden"},
-		{"project 1 - get field numbers", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "field", "numbers"}, "project1-field-numbers.golden"},
-		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "count(numbers)", "by", "xyz"}, "project1-eval-1.golden"},
-		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "count(numbers)"}, "project1-eval-2.golden"},
-		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "=1+1"}, "project1-eval-3.golden"},
-		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "1+1"}, "project1-eval-4.golden"},
-		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "by", "numbers"}, "project1-eval-5.golden"},
-		{"project 1 - get objects", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "objects"}, "project1-objects.golden"},
-		{"project 1 - get object data", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "object", "data", "my-hypercube"}, "project1-data.golden"},
-		{"project 1 - get object properties", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "object", "properties", "my-hypercube"}, "project1-properties.golden"},
-		{"project 1 - get object", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "object", "my-hypercube"}, "project1-properties.golden"},
-		{"project 1 - get measures 1", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures"}, "project1-measures-1.golden"},
-		{"project 1 - get measures 1 as json", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures", "--json"}, "project1-measures-1-json.golden"},
-		{"project 1 - get dimensions", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "dimensions"}, "project1-dimensions.golden"},
-		{"project 1 - get script", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "script"}, "project1-script.golden"},
-		{"project 1 - reload without progress", []string{"--config=test/project1/corectl.yml", connectToEngine, "reload", "--silent"}, "project1-reload-silent.golden"},
-		{"project 1 - reload without progress and without save", []string{"--config=test/project1/corectl.yml", connectToEngine, "reload", "--silent", "--no-save"}, "project1-reload-silent-no-save.golden"},
-		{"project 1 - set measures", []string{"--config=test/project1/corectl.yml ", connectToEngine, "set", "measures", "test/project1/not-following-glob-pattern-measure.json", "--no-save"}, "blank.golden"},
-		{"project 1 - get measures 2", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures"}, "project1-measures-2.golden"},
-		{"project 1 - remove measures", []string{"--config=test/project1/corectl.yml ", connectToEngine, "remove", "measures", "measure-3", "--no-save"}, "blank.golden"},
-		{"project 1 - check measures after removal", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures"}, "project1-measures-1.golden"},
-		{"project 1 - set script", []string{"--config=test/project1/corectl.yml ", connectToEngine, "set", "script", "test/project1/dummy-script.qvs", "--no-save"}, "blank.golden"},
-		{"project 1 - get script after setting it", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "script"}, "project1-script-2.golden"},
+	cmd := exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "build", "--connections=test/project2/connections.yml"}...)
+	cmd.Run()
+	cmd = exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "get", "connections", "--json"}...)
+	output, _ := cmd.CombinedOutput()
 
-		// Project 2 has separate connections file
-		{"project 2 - build with connections", []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "build", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, "project2-build.golden"},
-		{"project 2 - get fields ", []string{"--config=test/project2/corectl.yml ", connectToEngine, "get", "fields"}, "project2-fields.golden"},
-		{"project 2 - get data", []string{"--config=test/project2/corectl.yml ", connectToEngine, "get", "object", "data", "my-hypercube-on-commandline"}, "project2-data.golden"},
+	//verify that the connection was created
+	var connections []*enigma.Connection
+	err := json.Unmarshal(output, &connections)
+	assert.NoError(t, err)
+	assert.NotNil(t, connections[0])
+	assert.NotNil(t, connections[0].Id)
 
-		{"project 3 - build ", []string{"--config=test/project3/corectl.yml ", connectToEngine, "build"}, "project3-build.golden"},
-		{"project 3 - get fields", []string{"--config=test/project3/corectl.yml ", connectToEngine, "get", "fields"}, "project3-fields.golden"},
-		{"err project 1 - invalid-catwalk-url", []string{"--config=test/project1/corectl.yml", connectToEngine, "catwalk", "--catwalk-url=not-a-valid-url"}, "project1-catwalk-error.golden"},
-		{"err 2", []string{connectToEngine, "--app=nosuchapp.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "eval", "count(numbers)", "by", "xyz"}, "err-2.golden"},
-		{"err 3", []string{connectToEngine, "--app=project1.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "get", "object", "data", "nosuchobject"}, "err-3.golden"},
-	}
+	//verify that removing the connection works
+	cmd = exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "remove", "connection", connections[0].Id}...)
+	output, _ = cmd.CombinedOutput()
+	assert.Equal(t, "Saving...Done\n\n", string(output))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath, tt.args...)
-			output, err := cmd.CombinedOutput()
-			if strings.HasPrefix(tt.name, "err") {
-				if err == nil {
-					t.Fatalf("%s\nexpected (err == nil) to be %v, but got %v. err: %v", output, false, err == nil, err)
-				}
-			} else if err != nil {
-				t.Fatalf("%s\nexpected (err != nil) to be %v, but got %v. err: %v", output, false, err != nil, err)
-			}
-			actual := string(output)
+	//verify that there is no connections in the app anymore.
+	cmd = exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "get", "connections", "--json"}...)
+	output, _ = cmd.CombinedOutput()
+	assert.Equal(t, "[]\n", string(output))
 
-			golden := newGoldenFile(t, tt.golden)
-
-			if *update {
-				golden.write(actual)
-			}
-			expected := golden.load()
-
-			if !reflect.DeepEqual(expected, actual) {
-				t.Fatalf("diff: %v", diff(expected, actual))
-			}
-		})
-	}
+	//remove the app as clean-up (Otherwise we might share sessions when we use that app again.)
+	_ = exec.Command(binaryPath, []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "remove", "app", "project1.qvf"}...)
 }
 
-func TestCorectlContains(t *testing.T) {
+func TestCorectl(t *testing.T) {
 	connectToEngine := "--engine=" + *engineIP
 	tests := []struct {
 		name     string
 		args     []string
-		contains []string
+		expected []string
 	}{
+		{"help 1", []string{""}, []string{"golden", "help-1.golden"}},
+		{"help 2", []string{"help"}, []string{"golden", "help-2.golden"}},
+		{"help 3", []string{"help", "build"}, []string{"golden", "help-3.golden"}},
+		{"project 1 - build", []string{"--config=test/project1/corectl.yml", connectToEngine, "build"}, []string{"Connected", "TableA <<  5 Lines fetched", "TableB <<  5 Lines fetched", "Reload finished successfully", "Saving...Done"}},
+		{"project 1 - get tables", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "tables"}, []string{"golden", "project1-tables.golden"}},
+		{"project 1 - get assoc", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "assoc"}, []string{"golden", "project1-assoc.golden"}},
+		{"project 1 - get fields", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "fields"}, []string{"golden", "project1-fields.golden"}},
+		{"project 1 - get field numbers", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "field", "numbers"}, []string{"golden", "project1-field-numbers.golden"}},
+		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "count(numbers)", "by", "xyz"}, []string{"golden", "project1-eval-1.golden"}},
+		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "count(numbers)"}, []string{"golden", "project1-eval-2.golden"}},
+		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "=1+1"}, []string{"golden", "project1-eval-3.golden"}},
+		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "1+1"}, []string{"golden", "project1-eval-4.golden"}},
+		{"project 1 - eval", []string{"--config=test/project1/corectl.yml ", connectToEngine, "eval", "by", "numbers"}, []string{"golden", "project1-eval-5.golden"}},
+		{"project 1 - get objects", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "objects"}, []string{"golden", "project1-objects.golden"}},
+		{"project 1 - get object data", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "object", "data", "my-hypercube"}, []string{"golden", "project1-data.golden"}},
+		{"project 1 - get object properties", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "object", "properties", "my-hypercube"}, []string{"golden", "project1-properties.golden"}},
+		{"project 1 - get object", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "object", "my-hypercube"}, []string{"golden", "project1-properties.golden"}},
+		{"project 1 - get measures 1", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures"}, []string{"golden", "project1-measures-1.golden"}},
+		{"project 1 - get measures 1 as json", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures", "--json"}, []string{"golden", "project1-measures-1-json.golden"}},
+		{"project 1 - get dimensions", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "dimensions"}, []string{"golden", "project1-dimensions.golden"}},
+		{"project 1 - get script", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "script"}, []string{"golden", "project1-script.golden"}},
+		{"project 1 - reload without progress", []string{"--config=test/project1/corectl.yml", connectToEngine, "reload", "--silent"}, []string{"golden", "project1-reload-silent.golden"}},
+		{"project 1 - reload without progress and without save", []string{"--config=test/project1/corectl.yml", connectToEngine, "reload", "--silent", "--no-save"}, []string{"golden", "project1-reload-silent-no-save.golden"}},
+		{"project 1 - set measures", []string{"--config=test/project1/corectl.yml ", connectToEngine, "set", "measures", "test/project1/not-following-glob-pattern-measure.json", "--no-save"}, []string{"golden", "blank.golden"}},
+		{"project 1 - get measures 2", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures"}, []string{"golden", "project1-measures-2.golden"}},
+		{"project 1 - remove measures", []string{"--config=test/project1/corectl.yml ", connectToEngine, "remove", "measures", "measure-3", "--no-save"}, []string{"golden", "blank.golden"}},
+		{"project 1 - check measures after removal", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures"}, []string{"golden", "project1-measures-1.golden"}},
+		{"project 1 - set script", []string{"--config=test/project1/corectl.yml ", connectToEngine, "set", "script", "test/project1/dummy-script.qvs", "--no-save"}, []string{"golden", "blank.golden"}},
+		{"project 1 - get script after setting it", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "script"}, []string{"golden", "project1-script-2.golden"}},
+
+		// Project 2 has separate connections file
+		{"project 2 - build with connections", []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "build", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, []string{"datacsv << data 1 Lines fetched", "Reload finished successfully", "Saving...Done"}},
+		{"project 2 - get fields ", []string{"--config=test/project2/corectl.yml ", connectToEngine, "get", "fields"}, []string{"golden", "project2-fields.golden"}},
+		{"project 2 - get data", []string{"--config=test/project2/corectl.yml ", connectToEngine, "get", "object", "data", "my-hypercube-on-commandline"}, []string{"golden", "project2-data.golden"}},
+
+		{"project 3 - build ", []string{"--config=test/project3/corectl.yml ", connectToEngine, "build"}, []string{"No app specified, using session app.", "datacsv << data 1 Lines fetched", "Reload finished successfully"}},
+		{"project 3 - get fields", []string{"--config=test/project3/corectl.yml ", connectToEngine, "get", "fields"}, []string{"golden", "project3-fields.golden"}},
+		{"err project 1 - invalid-catwalk-url", []string{"--config=test/project1/corectl.yml", connectToEngine, "catwalk", "--catwalk-url=not-a-valid-url"}, []string{"golden", "project1-catwalk-error.golden"}},
+		{"err 2", []string{connectToEngine, "--app=nosuchapp.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "eval", "count(numbers)", "by", "xyz"}, []string{"golden", "err-2.golden"}},
+		{"err 3", []string{connectToEngine, "--app=project1.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "get", "object", "data", "nosuchobject"}, []string{"golden", "err-3.golden"}},
+
 		{"project 1 - get status", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "status"}, []string{"Connected to project1.qvf @ ", "The data model has 2 tables."}},
 		{"list apps", []string{connectToEngine, "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "get", "apps"}, []string{"Id", "Name", "Last-Reloaded", "ReadOnly", "Title", "project2.qvf", "project1.qvf"}},
 		{"list apps json", []string{connectToEngine, "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "get", "apps", "--json"}, []string{"\"id\": \"/apps/project2.qvf\","}},
@@ -181,9 +176,22 @@ func TestCorectlContains(t *testing.T) {
 			}
 			actual := string(output)
 
-			for _, sub := range tt.contains {
-				if !strings.Contains(actual, sub) {
-					t.Fatalf("Output did not contain substring %v", sub)
+			if tt.expected[0] == "golden" {
+				golden := newGoldenFile(t, tt.expected[1])
+
+				if *update {
+					golden.write(actual)
+				}
+				expected := golden.load()
+
+				if !reflect.DeepEqual(expected, actual) {
+					t.Fatalf("diff: %v", diff(expected, actual))
+				}
+			} else {
+				for _, sub := range tt.expected {
+					if !strings.Contains(actual, sub) {
+						t.Fatalf("Output did not contain substring %v", sub)
+					}
 				}
 			}
 		})

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -81,7 +81,6 @@ func (tf *testFile) load() string {
 
 func TestConnections(t *testing.T) {
 	connectToEngine := "--engine=" + *engineIP
-	fmt.Println("connect to engine: ", connectToEngine)
 	cmd := exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "build", "--connections=test/project2/connections.yml"}...)
 	cmd.Run()
 	cmd = exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "get", "connections", "--json"}...)

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -23,7 +23,6 @@ import (
 var update = flag.Bool("update", false, "update golden files")
 
 var engineIP = flag.String("engineIP", "localhost:9076", "dir of package containing embedded files")
-var connectToEngine = "--engine=" + *engineIP
 
 func getBinaryName() string {
 	if runtime.GOOS == "windows" {
@@ -81,6 +80,8 @@ func (tf *testFile) load() string {
 }
 
 func TestConnections(t *testing.T) {
+	connectToEngine := "--engine=" + *engineIP
+	fmt.Println("connect to engine: ", connectToEngine)
 	cmd := exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "build", "--connections=test/project2/connections.yml"}...)
 	cmd.Run()
 	cmd = exec.Command(binaryPath, []string{connectToEngine, "--config=test/project2/corectl.yml", "get", "connections", "--json"}...)
@@ -108,6 +109,7 @@ func TestConnections(t *testing.T) {
 }
 
 func TestCorectl(t *testing.T) {
+	connectToEngine := "--engine=" + *engineIP
 	tests := []struct {
 		name     string
 		args     []string

--- a/test/golden/help-1.golden
+++ b/test/golden/help-1.golden
@@ -11,7 +11,7 @@ Available Commands:
   get           Lists one or several resources
   help          Help about any command
   reload        Reloads the app.
-  remove        Remove one or mores generic entities (dimensions, measures, objects) in the app
+  remove        Remove entities (connections, dimensions, measures, objects) in the app or the app itself
   set           Sets one or several resources
   version       Print the version of corectl
 

--- a/test/golden/help-2.golden
+++ b/test/golden/help-2.golden
@@ -11,7 +11,7 @@ Available Commands:
   get           Lists one or several resources
   help          Help about any command
   reload        Reloads the app.
-  remove        Remove one or mores generic entities (dimensions, measures, objects) in the app
+  remove        Remove entities (connections, dimensions, measures, objects) in the app or the app itself
   set           Sets one or several resources
   version       Print the version of corectl
 

--- a/test/golden/help-3.golden
+++ b/test/golden/help-3.golden
@@ -4,7 +4,7 @@ Usage:
   corectl build [flags]
 
 Flags:
-  -a, --app string               App name including .qvf file ending. If no app is specified a session app is used instead.
+  -a, --app string               App name, if no app is specified a session app is used instead.
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --connections string       path/to/connections.yml that contains connections that are used in the reload. Note that when specifying connections in the config file they are specified inline, not as a file reference!
       --dimensions string        A list of generic dimension json paths

--- a/test/golden/project1-build.golden
+++ b/test/golden/project1-build.golden
@@ -1,6 +1,0 @@
-Connected
-TableA <<  5 Lines fetched
-TableB <<  5 Lines fetched
-Reload finished successfully
-Saving...Done
-

--- a/test/golden/project1-reload.golden
+++ b/test/golden/project1-reload.golden
@@ -1,6 +1,0 @@
-Connected
-TableA <<  5 Lines fetched
-TableB <<  5 Lines fetched
-Reload finished successfully
-Saving...Done
-

--- a/test/golden/project2-build.golden
+++ b/test/golden/project2-build.golden
@@ -1,4 +1,0 @@
-datacsv << data 1 Lines fetched
-Reload finished successfully
-Saving...Done
-

--- a/test/golden/project3-build.golden
+++ b/test/golden/project3-build.golden
@@ -1,3 +1,0 @@
-No app specified, using session app.
-datacsv << data 1 Lines fetched
-Reload finished successfully


### PR DESCRIPTION
This PR adds the possibility to remove connections and apps.
(Before you could only remove generic entities)

It also gives you the possibility to view what connectors are inside your app
`corectl get connections` and `corectl get connection connection-id` respectively.

We have a potential problem that some tests are dependent on running order (I.E first test creates the app, the next tests checks that there are objects inside the app) 

I think this should be cleaned up, but it might take some time, and is not part of this issue.

This closes #102 

