### PR TITLE
Only use the table names from "GetTableAndKeys"

### DIFF
--- a/internal/modeldata.go
+++ b/internal/modeldata.go
@@ -91,15 +91,10 @@ func createFieldModels(ctx context.Context, doc *enigma.Doc, fieldNames []string
 	return result
 }
 
-func createTableModels(ctx context.Context, doc *enigma.Doc, tableNames []string, tableRecords []*enigma.TableRecord, restMetadata *RestMetadata) []*TableModel {
-	tableRecordMap := make(map[string]*enigma.TableRecord)
-	for _, tableRecord := range tableRecords {
-		tableRecordMap[tableRecord.Name] = tableRecord
-	}
-
-	tableModels := make([]*TableModel, len(tableNames))
-	for i, tableName := range tableNames {
-		tableModels[i] = &TableModel{TableRecord: tableRecordMap[tableName], RestMetadata: restMetadata.tableByName(tableName)}
+func createTableModels(ctx context.Context, doc *enigma.Doc, tableRecords []*enigma.TableRecord, restMetadata *RestMetadata) []*TableModel {
+	tableModels := make([]*TableModel, len(tableRecords))
+	for i, tableRecord := range tableRecords {
+		tableModels[i] = &TableModel{TableRecord: tableRecord, RestMetadata: restMetadata.tableByName(tableRecord.Name)}
 	}
 	return tableModels
 }
@@ -132,10 +127,10 @@ func GetModelMetadata(ctx context.Context, doc *enigma.Doc, metaURL string, head
 	if len(tables) > 0 && restMetadata == nil {
 		fmt.Println("No REST metadata available.")
 	}
-	tableNames, fieldNames := getSortedTableNamesAndFieldsNames(ctx, doc, err, tables)
+	fieldNames := getSortedFieldsNames(ctx, doc, err)
 
 	fieldModels := createFieldModels(ctx, doc, fieldNames, restMetadata)
-	tableModels := createTableModels(ctx, doc, tableNames, tables, restMetadata)
+	tableModels := createTableModels(ctx, doc, tables, restMetadata)
 	fieldsInTableTexts := tableRecordsToMap(tables)
 	addTableFieldCellCrossReferences(fieldModels, tableModels)
 	return &ModelMetadata{

--- a/internal/systemtable.go
+++ b/internal/systemtable.go
@@ -3,19 +3,20 @@ package internal
 import (
 	"context"
 	"fmt"
-	"github.com/qlik-oss/enigma-go"
 	"os"
+
+	"github.com/qlik-oss/enigma-go"
 )
 
-func getSortedTableNamesAndFieldsNames(ctx context.Context, doc *enigma.Doc, err error, tables []*enigma.TableRecord) ([]string, []string) {
+func getSortedFieldsNames(ctx context.Context, doc *enigma.Doc, err error) []string {
 	systemTableObject := createSystemTableHypercube(ctx, doc)
 	systemTableLayout, err := systemTableObject.GetLayout(ctx)
 	if err != nil {
 		fmt.Println("Error when fetching system table:", err)
 		os.Exit(1)
 	}
-	tableNames, fieldNames := layoutToFieldListsAndTableLists(systemTableLayout)
-	return tableNames, fieldNames
+	fieldNames := layoutToFieldLists(systemTableLayout)
+	return fieldNames
 }
 
 func createSystemTableHypercube(ctx context.Context, doc *enigma.Doc) *enigma.GenericObject {
@@ -57,20 +58,15 @@ func createSystemTableHypercube(ctx context.Context, doc *enigma.Doc) *enigma.Ge
 	return object
 }
 
-func layoutToFieldListsAndTableLists(systemTableLayout *enigma.GenericObjectLayout) ([]string, []string) {
+func layoutToFieldLists(systemTableLayout *enigma.GenericObjectLayout) []string {
 
 	page := systemTableLayout.HyperCube.PivotDataPages[0]
-	tableNames := make([]string, len(page.Top))
 	fieldNames := make([]string, len(page.Left))
-
-	for x, tableName := range page.Top {
-		tableNames[x] = tableName.Text
-	}
 
 	for y := range page.Data {
 		fieldName := page.Left[y].Text
 		fieldNames[y] = fieldName
 	}
 
-	return tableNames, fieldNames
+	return fieldNames
 }


### PR DESCRIPTION
This fixes #122

Now you get the same tables that you get in Qlik Sense

There seems to be a mismatch between the tables that are included by using `GetTableAndKeys` and when using this hypercube

```
	object, _ := doc.CreateSessionObject(ctx, &enigma.GenericObjectProperties{
		Info: &enigma.NxInfo{
			Type: "my-pivot-hypercube",
		},
		HyperCubeDef: &enigma.HyperCubeDef{
			Dimensions: []*enigma.NxDimension{
				{
					Def: &enigma.NxInlineDimensionDef{
						FieldDefs:     []string{"=$Field"},
						SortCriterias: []*enigma.SortCriteria{{SortByExpression: -1, Expression: &enigma.ValueExpr{V: "=count($Table)"}}},
					},
				},
				{
					Def: &enigma.NxInlineDimensionDef{
						FieldDefs:     []string{"=$Table"},
						SortCriterias: []*enigma.SortCriteria{{SortByExpression: -1, Expression: &enigma.ValueExpr{V: "=count($Field)"}}},
					},
				},
			},
			Measures: []*enigma.NxMeasure{
				createMeasureSortNumeric("=sum($Rows)", &enigma.SortCriteria{SortByNumeric: -1}),
			},

			InitialDataFetch: []*enigma.NxPage{{
				Height: 1000,
				Width:  1000,
			}},
			Mode:         "P",
			NoOfLeftDims: &noOfLeftDims,
		},
	})
```

I think the later one returns a few system tables? that I think should not be included (if we want to include them we will have to handle this in another way so corectl does not crash when there is a system table that has no table record)

In the `Sales_Anaylsis.qvf` app it was the tables: `_tabToday`,`Dimensions`,`Measures` that was the problem.

