### PR TITLE
Add parameter for logging JSON traffic to stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 *.exe
 corectl
 corectl.exe
+main

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -14,7 +14,7 @@ corectl [flags]
 
 ```
   -h, --help      help for corectl
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -14,6 +14,7 @@ corectl [flags]
 
 ```
   -h, --help      help for corectl
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -32,7 +32,7 @@ corectl build [flags]
 ### Options inherited from parent commands
 
 ```
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -32,6 +32,7 @@ corectl build [flags]
 ### Options inherited from parent commands
 
 ```
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -30,6 +30,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
 ### Options inherited from parent commands
 
 ```
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -30,7 +30,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
 ### Options inherited from parent commands
 
 ```
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -33,6 +33,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
 ### Options inherited from parent commands
 
 ```
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -33,7 +33,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
 ### Options inherited from parent commands
 
 ```
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_get.md
+++ b/docs/corectl_get.md
@@ -19,6 +19,7 @@ Lists one or several resources
 ### Options inherited from parent commands
 
 ```
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_get.md
+++ b/docs/corectl_get.md
@@ -19,7 +19,7 @@ Lists one or several resources
 ### Options inherited from parent commands
 
 ```
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_get_apps.md
+++ b/docs/corectl_get_apps.md
@@ -23,7 +23,7 @@ corectl get apps [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_apps.md
+++ b/docs/corectl_get_apps.md
@@ -23,6 +23,7 @@ corectl get apps [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_assoc.md
+++ b/docs/corectl_get_assoc.md
@@ -23,6 +23,7 @@ corectl get assoc [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_assoc.md
+++ b/docs/corectl_get_assoc.md
@@ -23,7 +23,7 @@ corectl get assoc [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_connection.md
+++ b/docs/corectl_get_connection.md
@@ -29,6 +29,7 @@ corectl get connection CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_connection.md
+++ b/docs/corectl_get_connection.md
@@ -29,7 +29,7 @@ corectl get connection CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_connections.md
+++ b/docs/corectl_get_connections.md
@@ -30,7 +30,7 @@ corectl get connections
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_connections.md
+++ b/docs/corectl_get_connections.md
@@ -30,6 +30,7 @@ corectl get connections
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_dimension.md
+++ b/docs/corectl_get_dimension.md
@@ -23,6 +23,7 @@ corectl get dimension <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_dimension.md
+++ b/docs/corectl_get_dimension.md
@@ -23,7 +23,7 @@ corectl get dimension <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_dimension_layout.md
+++ b/docs/corectl_get_dimension_layout.md
@@ -23,6 +23,7 @@ corectl get dimension layout <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_dimension_layout.md
+++ b/docs/corectl_get_dimension_layout.md
@@ -23,7 +23,7 @@ corectl get dimension layout <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_dimension_properties.md
+++ b/docs/corectl_get_dimension_properties.md
@@ -23,7 +23,7 @@ corectl get dimension properties <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_dimension_properties.md
+++ b/docs/corectl_get_dimension_properties.md
@@ -23,6 +23,7 @@ corectl get dimension properties <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_dimensions.md
+++ b/docs/corectl_get_dimensions.md
@@ -24,7 +24,7 @@ corectl get dimensions [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_dimensions.md
+++ b/docs/corectl_get_dimensions.md
@@ -24,6 +24,7 @@ corectl get dimensions [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_field.md
+++ b/docs/corectl_get_field.md
@@ -23,6 +23,7 @@ corectl get field <field name> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_field.md
+++ b/docs/corectl_get_field.md
@@ -23,7 +23,7 @@ corectl get field <field name> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_fields.md
+++ b/docs/corectl_get_fields.md
@@ -23,6 +23,7 @@ corectl get fields [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_fields.md
+++ b/docs/corectl_get_fields.md
@@ -23,7 +23,7 @@ corectl get fields [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_keys.md
+++ b/docs/corectl_get_keys.md
@@ -23,7 +23,7 @@ corectl get keys [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_keys.md
+++ b/docs/corectl_get_keys.md
@@ -23,6 +23,7 @@ corectl get keys [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_measure.md
+++ b/docs/corectl_get_measure.md
@@ -23,7 +23,7 @@ corectl get measure <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_measure.md
+++ b/docs/corectl_get_measure.md
@@ -23,6 +23,7 @@ corectl get measure <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_measure_layout.md
+++ b/docs/corectl_get_measure_layout.md
@@ -23,7 +23,7 @@ corectl get measure layout <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_measure_layout.md
+++ b/docs/corectl_get_measure_layout.md
@@ -23,6 +23,7 @@ corectl get measure layout <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_measure_properties.md
+++ b/docs/corectl_get_measure_properties.md
@@ -23,6 +23,7 @@ corectl get measure properties <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_measure_properties.md
+++ b/docs/corectl_get_measure_properties.md
@@ -23,7 +23,7 @@ corectl get measure properties <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_measures.md
+++ b/docs/corectl_get_measures.md
@@ -24,7 +24,7 @@ corectl get measures [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_measures.md
+++ b/docs/corectl_get_measures.md
@@ -24,6 +24,7 @@ corectl get measures [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_meta.md
+++ b/docs/corectl_get_meta.md
@@ -23,7 +23,7 @@ corectl get meta [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_meta.md
+++ b/docs/corectl_get_meta.md
@@ -23,6 +23,7 @@ corectl get meta [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_object.md
+++ b/docs/corectl_get_object.md
@@ -23,7 +23,7 @@ corectl get object <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_object.md
+++ b/docs/corectl_get_object.md
@@ -23,6 +23,7 @@ corectl get object <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_object_data.md
+++ b/docs/corectl_get_object_data.md
@@ -23,7 +23,7 @@ corectl get object data <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_object_data.md
+++ b/docs/corectl_get_object_data.md
@@ -23,6 +23,7 @@ corectl get object data <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_object_layout.md
+++ b/docs/corectl_get_object_layout.md
@@ -23,7 +23,7 @@ corectl get object layout <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_object_layout.md
+++ b/docs/corectl_get_object_layout.md
@@ -23,6 +23,7 @@ corectl get object layout <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_object_properties.md
+++ b/docs/corectl_get_object_properties.md
@@ -23,6 +23,7 @@ corectl get object properties <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_object_properties.md
+++ b/docs/corectl_get_object_properties.md
@@ -23,7 +23,7 @@ corectl get object properties <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_objects.md
+++ b/docs/corectl_get_objects.md
@@ -24,6 +24,7 @@ corectl get objects [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_objects.md
+++ b/docs/corectl_get_objects.md
@@ -24,7 +24,7 @@ corectl get objects [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_script.md
+++ b/docs/corectl_get_script.md
@@ -23,7 +23,7 @@ corectl get script [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_script.md
+++ b/docs/corectl_get_script.md
@@ -23,6 +23,7 @@ corectl get script [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_status.md
+++ b/docs/corectl_get_status.md
@@ -23,7 +23,7 @@ corectl get status [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_status.md
+++ b/docs/corectl_get_status.md
@@ -23,6 +23,7 @@ corectl get status [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_tables.md
+++ b/docs/corectl_get_tables.md
@@ -23,7 +23,7 @@ corectl get tables [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_get_tables.md
+++ b/docs/corectl_get_tables.md
@@ -23,6 +23,7 @@ corectl get tables [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -26,6 +26,7 @@ corectl reload [flags]
 ### Options inherited from parent commands
 
 ```
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -26,7 +26,7 @@ corectl reload [flags]
 ### Options inherited from parent commands
 
 ```
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_remove.md
+++ b/docs/corectl_remove.md
@@ -19,6 +19,7 @@ Remove one or mores generic entities (connections, dimensions, measures, objects
 ### Options inherited from parent commands
 
 ```
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_remove.md
+++ b/docs/corectl_remove.md
@@ -19,7 +19,7 @@ Remove one or mores generic entities (connections, dimensions, measures, objects
 ### Options inherited from parent commands
 
 ```
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_remove_app.md
+++ b/docs/corectl_remove_app.md
@@ -28,7 +28,7 @@ corectl remove app APP-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_app.md
+++ b/docs/corectl_remove_app.md
@@ -28,6 +28,7 @@ corectl remove app APP-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_connection.md
+++ b/docs/corectl_remove_connection.md
@@ -30,7 +30,7 @@ corectl remove connection CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_connection.md
+++ b/docs/corectl_remove_connection.md
@@ -30,6 +30,7 @@ corectl remove connection CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_dimensions.md
+++ b/docs/corectl_remove_dimensions.md
@@ -24,7 +24,7 @@ corectl remove dimensions <dimension-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_dimensions.md
+++ b/docs/corectl_remove_dimensions.md
@@ -24,6 +24,7 @@ corectl remove dimensions <dimension-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_measures.md
+++ b/docs/corectl_remove_measures.md
@@ -24,6 +24,7 @@ corectl remove measures <measure-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_measures.md
+++ b/docs/corectl_remove_measures.md
@@ -24,7 +24,7 @@ corectl remove measures <measure-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_objects.md
+++ b/docs/corectl_remove_objects.md
@@ -24,7 +24,7 @@ corectl remove objects <object-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_remove_objects.md
+++ b/docs/corectl_remove_objects.md
@@ -24,6 +24,7 @@ corectl remove objects <object-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set.md
+++ b/docs/corectl_set.md
@@ -21,7 +21,7 @@ Sets one or several resources
 ### Options inherited from parent commands
 
 ```
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_set.md
+++ b/docs/corectl_set.md
@@ -21,6 +21,7 @@ Sets one or several resources
 ### Options inherited from parent commands
 
 ```
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_set_all.md
+++ b/docs/corectl_set_all.md
@@ -29,7 +29,7 @@ corectl set all [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_all.md
+++ b/docs/corectl_set_all.md
@@ -29,6 +29,7 @@ corectl set all [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_connections.md
+++ b/docs/corectl_set_connections.md
@@ -25,6 +25,7 @@ corectl set connections <path-to-connections-file.yml> [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_connections.md
+++ b/docs/corectl_set_connections.md
@@ -25,7 +25,7 @@ corectl set connections <path-to-connections-file.yml> [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_dimensions.md
+++ b/docs/corectl_set_dimensions.md
@@ -24,6 +24,7 @@ corectl set dimensions <glob-pattern-path-to-dimensions-files.json> [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_dimensions.md
+++ b/docs/corectl_set_dimensions.md
@@ -24,7 +24,7 @@ corectl set dimensions <glob-pattern-path-to-dimensions-files.json> [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_measures.md
+++ b/docs/corectl_set_measures.md
@@ -24,6 +24,7 @@ corectl set measures <glob-pattern-path-to-measures-files.json> [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_measures.md
+++ b/docs/corectl_set_measures.md
@@ -24,7 +24,7 @@ corectl set measures <glob-pattern-path-to-measures-files.json> [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_objects.md
+++ b/docs/corectl_set_objects.md
@@ -24,6 +24,7 @@ corectl set objects <glob-pattern-path-to-objects-files.json [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_objects.md
+++ b/docs/corectl_set_objects.md
@@ -24,7 +24,7 @@ corectl set objects <glob-pattern-path-to-objects-files.json [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_script.md
+++ b/docs/corectl_set_script.md
@@ -24,7 +24,7 @@ corectl set script <path-to-script-file.yml> [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
-  -t, --traffic                  Log JSON traffic to stdout
+  -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_set_script.md
+++ b/docs/corectl_set_script.md
@@ -24,6 +24,7 @@ corectl set script <path-to-script-file.yml> [flags]
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
       --no-save                  Do not save the app
+  -t, --traffic                  Log JSON traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information
 ```

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -19,6 +19,7 @@ corectl version [flags]
 ### Options inherited from parent commands
 
 ```
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -19,7 +19,7 @@ corectl version [flags]
 ### Options inherited from parent commands
 
 ```
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 ```
 

--- a/internal/log.go
+++ b/internal/log.go
@@ -12,18 +12,24 @@ func LogVerbose(message string) {
 	}
 }
 
+// LogTraffic is set to true when websocket traffic should be printed to stdout
 var LogTraffic bool
 
+// TrafficLogger is a struct implementing the TrafficLogger interface in enigma-go
 type TrafficLogger struct{}
 
-func (l *TrafficLogger) Opened() {}
+// Opened implements Opened() method in enigma-go TrafficLogger interface
+func (TrafficLogger) Opened() {}
 
-func (l *TrafficLogger) Sent(message []byte) {
-	fmt.Println("-->", string(message[:]))
+// Sent implements Sent() method in enigma-go TrafficLogger interface
+func (TrafficLogger) Sent(message []byte) {
+	fmt.Println("-->", string(message))
 }
 
-func (l *TrafficLogger) Received(message []byte) {
-	fmt.Println("<--", string(message[:]))
+// Received implements Received() method in enigma-go TrafficLogger interface
+func (TrafficLogger) Received(message []byte) {
+	fmt.Println("<--", string(message))
 }
 
-func (l *TrafficLogger) Closed() {}
+// Closed implements Closed() method in enigma-go TrafficLogger interface
+func (TrafficLogger) Closed() {}

--- a/internal/log.go
+++ b/internal/log.go
@@ -11,3 +11,19 @@ func LogVerbose(message string) {
 		fmt.Println(message)
 	}
 }
+
+var LogTraffic bool
+
+type TrafficLogger struct{}
+
+func (l *TrafficLogger) Opened() {}
+
+func (l *TrafficLogger) Sent(message []byte) {
+	fmt.Println("-->", string(message[:]))
+}
+
+func (l *TrafficLogger) Received(message []byte) {
+	fmt.Println("<--", string(message[:]))
+}
+
+func (l *TrafficLogger) Closed() {}

--- a/internal/state.go
+++ b/internal/state.go
@@ -53,7 +53,7 @@ func connectToEngine(ctx context.Context, engine string, appID string, ttl strin
 	var dialer enigma.Dialer
 
 	if LogTraffic {
-		dialer = enigma.Dialer{TrafficLogger: &TrafficLogger{}}
+		dialer = enigma.Dialer{TrafficLogger: TrafficLogger{}}
 	} else {
 		dialer = enigma.Dialer{}
 	}
@@ -175,7 +175,7 @@ func PrepareEngineStateWithoutApp(ctx context.Context, engine string, ttl string
 	var dialer enigma.Dialer
 
 	if LogTraffic {
-		dialer = enigma.Dialer{TrafficLogger: &TrafficLogger{}}
+		dialer = enigma.Dialer{TrafficLogger: TrafficLogger{}}
 	} else {
 		dialer = enigma.Dialer{}
 	}

--- a/internal/state.go
+++ b/internal/state.go
@@ -50,7 +50,15 @@ func connectToEngine(ctx context.Context, engine string, appID string, ttl strin
 	}
 	LogVerbose("SessionId " + headers.Get("X-Qlik-Session"))
 
-	global, err := enigma.Dialer{}.Dial(ctx, engineURL, headers)
+	var dialer enigma.Dialer
+
+	if LogTraffic {
+		dialer = enigma.Dialer{TrafficLogger: &TrafficLogger{}}
+	} else {
+		dialer = enigma.Dialer{}
+	}
+
+	global, err := dialer.Dial(ctx, engineURL, headers)
 	if err != nil {
 		logConnectError(err, engine)
 	}
@@ -163,7 +171,16 @@ func PrepareEngineStateWithoutApp(ctx context.Context, engine string, ttl string
 	engineURL := buildWebSocketURL(engine, ttl)
 
 	LogVerbose("Engine: " + engineURL)
-	global, err := enigma.Dialer{}.Dial(ctx, engineURL, headers)
+
+	var dialer enigma.Dialer
+
+	if LogTraffic {
+		dialer = enigma.Dialer{TrafficLogger: &TrafficLogger{}}
+	} else {
+		dialer = enigma.Dialer{}
+	}
+
+	global, err := dialer.Dial(ctx, engineURL, headers)
 
 	if err != nil {
 		logConnectError(err, engine)

--- a/main.go
+++ b/main.go
@@ -966,7 +966,7 @@ func init() {
 	corectlCommand.PersistentFlags().BoolP("verbose", "v", false, "Logs extra information")
 	viper.BindPFlag("verbose", corectlCommand.PersistentFlags().Lookup("verbose"))
 
-	corectlCommand.PersistentFlags().BoolP("traffic", "t", false, "Log JSON traffic to stdout")
+	corectlCommand.PersistentFlags().BoolP("traffic", "t", false, "Log JSON websocket traffic to stdout")
 	viper.BindPFlag("traffic", corectlCommand.PersistentFlags().Lookup("traffic"))
 
 	//Is it nicer to have one loop per argument or group the commands together if they all are used in the same commands?

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 				return
 			}
 			internal.QliVerbose = viper.GetBool("verbose")
+			internal.LogTraffic = viper.GetBool("traffic")
 			if explicitConfigFile != "" {
 				viper.SetConfigFile(strings.TrimSpace(explicitConfigFile))
 				if err := viper.ReadInConfig(); err == nil {
@@ -52,7 +53,6 @@ var (
 					internal.LogVerbose("No config file")
 				}
 			}
-			internal.QliVerbose = viper.GetBool("verbose")
 
 			if len(headersMap) == 0 {
 				headersMap = viper.GetStringMapString("headers")
@@ -965,6 +965,9 @@ func init() {
 
 	corectlCommand.PersistentFlags().BoolP("verbose", "v", false, "Logs extra information")
 	viper.BindPFlag("verbose", corectlCommand.PersistentFlags().Lookup("verbose"))
+
+	corectlCommand.PersistentFlags().BoolP("traffic", "t", false, "Log JSON traffic to stdout")
+	viper.BindPFlag("traffic", corectlCommand.PersistentFlags().Lookup("traffic"))
 
 	//Is it nicer to have one loop per argument or group the commands together if they all are used in the same commands?
 	for _, command := range []*cobra.Command{buildCmd, catwalkCmd, evalCmd, getCmd, reloadCmd, removeCmd, setCmd} {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -145,7 +145,7 @@ func TestCorectl(t *testing.T) {
 		{"project 1 - check measures after removal", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures"}, []string{"golden", "project1-measures-1.golden"}},
 		{"project 1 - set script", []string{"--config=test/project1/corectl.yml ", connectToEngine, "set", "script", "test/project1/dummy-script.qvs", "--no-save"}, []string{"golden", "blank.golden"}},
 		{"project 1 - get script after setting it", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "script"}, []string{"golden", "project1-script-2.golden"}},
-		{"project 1 - traffic logging", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "script", "--traffic"}, []string{"golden", "project1-traffic-log.golden"}},
+		{"project 1 - traffic logging", []string{"--config=test/project1/corectl.yml", connectToEngine, "get", "script", "--traffic"}, []string{"golden", "project1-traffic-log.golden"}},
 
 		// Project 2 has separate connections file
 		{"project 2 - build with connections", []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "build", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, []string{"datacsv << data 1 Lines fetched", "Reload finished successfully", "Saving...Done"}},

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -145,6 +145,7 @@ func TestCorectl(t *testing.T) {
 		{"project 1 - check measures after removal", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "measures"}, []string{"golden", "project1-measures-1.golden"}},
 		{"project 1 - set script", []string{"--config=test/project1/corectl.yml ", connectToEngine, "set", "script", "test/project1/dummy-script.qvs", "--no-save"}, []string{"golden", "blank.golden"}},
 		{"project 1 - get script after setting it", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "script"}, []string{"golden", "project1-script-2.golden"}},
+		{"project 1 - traffic logging", []string{"--config=test/project1/corectl.yml ", connectToEngine, "get", "script", "--traffic"}, []string{"golden", "project1-traffic-log.golden"}},
 
 		// Project 2 has separate connections file
 		{"project 2 - build with connections", []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0", "build", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, []string{"datacsv << data 1 Lines fetched", "Reload finished successfully", "Saving...Done"}},

--- a/test/golden/help-1.golden
+++ b/test/golden/help-1.golden
@@ -17,6 +17,7 @@ Available Commands:
 
 Flags:
   -h, --help      help for corectl
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 
 Use "corectl [command] --help" for more information about a command.

--- a/test/golden/help-1.golden
+++ b/test/golden/help-1.golden
@@ -17,7 +17,7 @@ Available Commands:
 
 Flags:
   -h, --help      help for corectl
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 
 Use "corectl [command] --help" for more information about a command.

--- a/test/golden/help-2.golden
+++ b/test/golden/help-2.golden
@@ -17,6 +17,7 @@ Available Commands:
 
 Flags:
   -h, --help      help for corectl
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information
 
 Use "corectl [command] --help" for more information about a command.

--- a/test/golden/help-2.golden
+++ b/test/golden/help-2.golden
@@ -17,7 +17,7 @@ Available Commands:
 
 Flags:
   -h, --help      help for corectl
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information
 
 Use "corectl [command] --help" for more information about a command.

--- a/test/golden/help-3.golden
+++ b/test/golden/help-3.golden
@@ -18,4 +18,5 @@ Flags:
       --ttl string               Engine session time to live in seconds (default "30")
 
 Global Flags:
+  -t, --traffic   Log JSON traffic to stdout
   -v, --verbose   Logs extra information

--- a/test/golden/help-3.golden
+++ b/test/golden/help-3.golden
@@ -18,5 +18,5 @@ Flags:
       --ttl string               Engine session time to live in seconds (default "30")
 
 Global Flags:
-  -t, --traffic   Log JSON traffic to stdout
+  -t, --traffic   Log JSON websocket traffic to stdout
   -v, --verbose   Logs extra information

--- a/test/golden/project1-traffic-log.golden
+++ b/test/golden/project1-traffic-log.golden
@@ -1,0 +1,10 @@
+<-- {"jsonrpc":"2.0","method":"OnConnected","params":{"qSessionState":"SESSION_ATTACHED"}}
+--> {"jsonrpc":"2.0","delta":false,"method":"GetActiveDoc","handle":-1,"id":1,"params":[]}
+<-- {"jsonrpc":"2.0","id":1,"result":{"qReturn":{"qType":"Doc","qHandle":1,"qGenericId":"/apps/project1.qvf"}}}
+--> {"jsonrpc":"2.0","delta":false,"method":"GetScript","handle":1,"id":2,"params":[]}
+<-- {"jsonrpc":"2.0","id":2,"result":{"qScript":"LIB CONNECT TO myconnection;\n\nTableA:\nSELECT A;\n"}}
+LIB CONNECT TO myconnection;
+
+TableA:
+SELECT A;
+


### PR DESCRIPTION
This PR adds a parameter `--traffic` or `-t` that enables JSON traffic logging to `stdout`.

Closes #116