### PR TITLE
Add parameter for opening an app without data

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -20,6 +20,7 @@ var getCmd = &cobra.Command{
 		rootCmd.PersistentPreRun(rootCmd, args)
 		viper.BindPFlag("engine", ccmd.PersistentFlags().Lookup("engine"))
 		viper.BindPFlag("ttl", ccmd.PersistentFlags().Lookup("ttl"))
+		viper.BindPFlag("no-data", ccmd.PersistentFlags().Lookup("no-data"))
 	},
 }
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -25,6 +25,7 @@ var removeCmd = &cobra.Command{
 		viper.BindPFlag("ttl", ccmd.PersistentFlags().Lookup("ttl"))
 		viper.BindPFlag("headers", ccmd.PersistentFlags().Lookup("headers"))
 		viper.BindPFlag("suppress", ccmd.PersistentFlags().Lookup("suppress"))
+		viper.BindPFlag("no-data", ccmd.PersistentFlags().Lookup("no-data"))
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,10 @@ func init() {
 		command.PersistentFlags().String("ttl", "30", "Engine session time to live in seconds")
 	}
 
+	for _, command := range []*cobra.Command{getCmd, removeCmd, setCmd} {
+		command.PersistentFlags().Bool("no-data", false, "Open app without data")
+	}
+
 	for _, command := range []*cobra.Command{buildCmd, evalCmd, getCmd, reloadCmd, setCmd, removeCmd} {
 		//not binding to viper since binding a map does not seem to work.
 		command.PersistentFlags().StringToStringVar(&headersMap, "headers", nil, "Headers to use when connecting to qix engine")

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -21,6 +21,7 @@ var setCmd = &cobra.Command{
 		viper.BindPFlag("engine", ccmd.PersistentFlags().Lookup("engine"))
 		viper.BindPFlag("no-save", ccmd.PersistentFlags().Lookup("no-save"))
 		viper.BindPFlag("ttl", ccmd.PersistentFlags().Lookup("ttl"))
+		viper.BindPFlag("no-data", ccmd.PersistentFlags().Lookup("no-data"))
 	},
 }
 

--- a/docs/corectl_get.md
+++ b/docs/corectl_get.md
@@ -13,6 +13,7 @@ Lists one or several resources
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
   -h, --help                     help for get
+      --no-data                  Open app without data
       --ttl string               Engine session time to live in seconds (default "30")
 ```
 

--- a/docs/corectl_get_apps.md
+++ b/docs/corectl_get_apps.md
@@ -23,6 +23,7 @@ corectl get apps [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_assoc.md
+++ b/docs/corectl_get_assoc.md
@@ -23,6 +23,7 @@ corectl get assoc [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_connection.md
+++ b/docs/corectl_get_connection.md
@@ -29,6 +29,7 @@ corectl get connection CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_connections.md
+++ b/docs/corectl_get_connections.md
@@ -30,6 +30,7 @@ corectl get connections
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_dimension.md
+++ b/docs/corectl_get_dimension.md
@@ -23,6 +23,7 @@ corectl get dimension <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_dimension_layout.md
+++ b/docs/corectl_get_dimension_layout.md
@@ -23,6 +23,7 @@ corectl get dimension layout <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_dimension_properties.md
+++ b/docs/corectl_get_dimension_properties.md
@@ -23,6 +23,7 @@ corectl get dimension properties <dimension-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_dimensions.md
+++ b/docs/corectl_get_dimensions.md
@@ -24,6 +24,7 @@ corectl get dimensions [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_field.md
+++ b/docs/corectl_get_field.md
@@ -23,6 +23,7 @@ corectl get field <field name> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_fields.md
+++ b/docs/corectl_get_fields.md
@@ -23,6 +23,7 @@ corectl get fields [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_keys.md
+++ b/docs/corectl_get_keys.md
@@ -23,6 +23,7 @@ corectl get keys [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_measure.md
+++ b/docs/corectl_get_measure.md
@@ -23,6 +23,7 @@ corectl get measure <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_measure_layout.md
+++ b/docs/corectl_get_measure_layout.md
@@ -23,6 +23,7 @@ corectl get measure layout <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_measure_properties.md
+++ b/docs/corectl_get_measure_properties.md
@@ -23,6 +23,7 @@ corectl get measure properties <measure-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_measures.md
+++ b/docs/corectl_get_measures.md
@@ -24,6 +24,7 @@ corectl get measures [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_meta.md
+++ b/docs/corectl_get_meta.md
@@ -23,6 +23,7 @@ corectl get meta [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_object.md
+++ b/docs/corectl_get_object.md
@@ -23,6 +23,7 @@ corectl get object <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_object_data.md
+++ b/docs/corectl_get_object_data.md
@@ -23,6 +23,7 @@ corectl get object data <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_object_layout.md
+++ b/docs/corectl_get_object_layout.md
@@ -23,6 +23,7 @@ corectl get object layout <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_object_properties.md
+++ b/docs/corectl_get_object_properties.md
@@ -23,6 +23,7 @@ corectl get object properties <object-id> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_objects.md
+++ b/docs/corectl_get_objects.md
@@ -24,6 +24,7 @@ corectl get objects [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_script.md
+++ b/docs/corectl_get_script.md
@@ -23,6 +23,7 @@ corectl get script [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_status.md
+++ b/docs/corectl_get_status.md
@@ -23,6 +23,7 @@ corectl get status [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_tables.md
+++ b/docs/corectl_get_tables.md
@@ -23,6 +23,7 @@ corectl get tables [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_remove.md
+++ b/docs/corectl_remove.md
@@ -14,6 +14,7 @@ Remove one or mores generic entities (connections, dimensions, measures, objects
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
   -h, --help                     help for remove
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
       --ttl string               Engine session time to live in seconds (default "30")
 ```

--- a/docs/corectl_remove_app.md
+++ b/docs/corectl_remove_app.md
@@ -29,6 +29,7 @@ corectl remove app APP-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_remove_connection.md
+++ b/docs/corectl_remove_connection.md
@@ -30,6 +30,7 @@ corectl remove connection CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_remove_dimensions.md
+++ b/docs/corectl_remove_dimensions.md
@@ -24,6 +24,7 @@ corectl remove dimensions <dimension-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_remove_measures.md
+++ b/docs/corectl_remove_measures.md
@@ -24,6 +24,7 @@ corectl remove measures <measure-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_remove_objects.md
+++ b/docs/corectl_remove_objects.md
@@ -24,6 +24,7 @@ corectl remove objects <object-id>... [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_set.md
+++ b/docs/corectl_set.md
@@ -14,6 +14,7 @@ Sets one or several resources
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
   -h, --help                     help for set
+      --no-data                  Open app without data
       --no-save                  Do not save the app
       --ttl string               Engine session time to live in seconds (default "30")
 ```

--- a/docs/corectl_set_all.md
+++ b/docs/corectl_set_all.md
@@ -28,6 +28,7 @@ corectl set all [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_connections.md
+++ b/docs/corectl_set_connections.md
@@ -24,6 +24,7 @@ corectl set connections <path-to-connections-file.yml> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_dimensions.md
+++ b/docs/corectl_set_dimensions.md
@@ -23,6 +23,7 @@ corectl set dimensions <glob-pattern-path-to-dimensions-files.json> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_measures.md
+++ b/docs/corectl_set_measures.md
@@ -23,6 +23,7 @@ corectl set measures <glob-pattern-path-to-measures-files.json> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_objects.md
+++ b/docs/corectl_set_objects.md
@@ -24,6 +24,7 @@ corectl set objects <glob-pattern-path-to-objects-files.json [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_script.md
+++ b/docs/corectl_set_script.md
@@ -23,6 +23,7 @@ corectl set script <path-to-script-file.yml> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to engine (default "localhost:9076")
       --headers stringToString   Headers to use when connecting to qix engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Engine session time to live in seconds (default "30")

--- a/internal/state.go
+++ b/internal/state.go
@@ -83,6 +83,7 @@ func PrepareEngineState(ctx context.Context, headers http.Header, createAppIfMis
 	engine := viper.GetString("engine")
 	appID := viper.GetString("app")
 	ttl := viper.GetString("ttl")
+	noData := viper.GetBool("no-data")
 
 	LogVerbose("---------- Connecting to app ----------")
 	global := connectToEngine(ctx, engine, appID, ttl, headers)
@@ -112,9 +113,13 @@ func PrepareEngineState(ctx context.Context, headers http.Header, createAppIfMis
 				FatalError(err)
 			}
 		} else {
-			doc, err = global.OpenDoc(ctx, appID, "", "", "", false)
+			doc, err = global.OpenDoc(ctx, appID, "", "", "", noData)
 			if doc != nil {
-				LogVerbose("App:  " + appID + "(opened)")
+				if noData {
+					LogVerbose("Opened app with id " + appID + " without data")
+				} else {
+					LogVerbose("Opened app with id " + appID)
+				}
 			} else if createAppIfMissing {
 				_, _, err = global.CreateApp(ctx, appID, "")
 				if err != nil {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package test
 
 import (

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package test
 
 import (
@@ -232,6 +230,7 @@ func TestCorectl(t *testing.T) {
 		{"project 1 - set script", defaultConnectString1, []string{"set", "script", "test/project1/dummy-script.qvs", "--no-save"}, []string{"golden", "blank.golden"}, initTest{true, true}},
 		{"project 1 - get script after setting it", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"get", "script"}, []string{"golden", "project1-script-2.golden"}, initTest{true, true}},
 		{"project 1 - traffic logging", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"get", "script", "--traffic"}, []string{"golden", "project1-traffic-log.golden"}, initTest{true, true}},
+		{"project 1 - open app without data", []string{"--config=test/project1/corectl-alt.yml", "--ttl", "0", connectToEngine}, []string{"get", "connections", "--no-data", "--verbose"}, []string{"without data"}, initTest{true, true}},
 
 		// Project 2 has separate connections file
 		{"project 2 - build with connections", []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0"}, []string{"build", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, []string{"datacsv << data 1 Lines fetched", "Reload finished successfully", "Saving...Done"}, initTest{false, true}},


### PR DESCRIPTION
This PR adds a parameter `--no-data` that can be passed to `get`,  `set` and `remove` commands. When set `corectl` will open a document without loading the data.