### PR TITLE
Check for latest release when running the version command

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -199,7 +199,7 @@ func checkLatestVersion() {
 		}
 
 		fmt.Println("-------------------------------------------------")
-		fmt.Printf("Version %s is not latest, you should upgrade to %s \n", version, res.Current)
+		fmt.Printf("There is a new version available! Please upgrade for the latest features and bug fixes. You are on %s, latest version is %s. \n", version, res.Current)
 		fmt.Printf("To download the latest version you can use this command: \n")
 		fmt.Printf(`'%s'`, dwnl)
 		fmt.Println("\n-------------------------------------------------")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
+	"github.com/tcnksm/go-latest"
 )
 
 var buildCmd = &cobra.Command{
@@ -114,6 +115,11 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version of corectl",
 
 	Run: func(_ *cobra.Command, args []string) {
+
+		if version != "development build" {
+			checkLatestVersion()
+		}
+
 		fmt.Printf("corectl version: %s\n", version)
 	},
 }
@@ -165,5 +171,19 @@ func build(ccmd *cobra.Command, args []string) {
 
 	if state.AppID != "" {
 		internal.Save(ctx, state.Doc, state.AppID)
+	}
+}
+
+// Function for checking current version against latest released version on github
+func checkLatestVersion() {
+	githubTag := &latest.GithubTag{
+		Owner:      "qlik-oss",
+		Repository: "corectl",
+	}
+
+	res, err := latest.Check(githubTag, version)
+
+	if err == nil && res.Outdated {
+		fmt.Printf("*** Version %s is not latest, you should upgrade to %s ***\n", version, res.Current)
 	}
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"runtime"
@@ -189,10 +188,7 @@ func checkLatestVersion() {
 	if err == nil && res.Outdated {
 
 		// Find absolute path of executable
-		executable, err := os.Executable()
-		if err != nil {
-			log.Fatal(err)
-		}
+		executable, _ := os.Executable()
 
 		// Format a download string depending on OS
 		var dwnl string

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"path"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/browser"
@@ -184,6 +187,25 @@ func checkLatestVersion() {
 	res, err := latest.Check(githubTag, version)
 
 	if err == nil && res.Outdated {
-		fmt.Printf("*** Version %s is not latest, you should upgrade to %s ***\n", version, res.Current)
+
+		// Find absolute path of executable
+		executable, err := os.Executable()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Format a download string depending on OS
+		var dwnl string
+		if runtime.GOOS == "windows" {
+			dwnl = fmt.Sprintf(`curl --silent --location "https://github.com/qlik-oss/corectl/releases/download/v%s/corectl-windows-x86_64.zip" > corectl.zip && unzip ./corectl.zip -d "%s" && rm ./corectl.zip`, res.Current, path.Dir(executable))
+		} else {
+			dwnl = fmt.Sprintf(`curl --silent --location "https://github.com/qlik-oss/corectl/releases/download/v%s/corectl-%s-x86_64.tar.gz" | tar xz -C /tmp && mv /tmp/corectl %s`, res.Current, runtime.GOOS, path.Dir(executable))
+		}
+
+		fmt.Println("-------------------------------------------------")
+		fmt.Printf("Version %s is not latest, you should upgrade to %s \n", version, res.Current)
+		fmt.Printf("To download the latest version you can use this command: \n")
+		fmt.Printf(`'%s'`, dwnl)
+		fmt.Println("\n-------------------------------------------------")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/buger/goterm v0.0.0-20190225113744-c206103e1f37
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
+	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/hashicorp/go-version v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/pretty v0.1.0
 	github.com/magiconair/properties v1.8.0
@@ -13,6 +16,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.1
 	github.com/stretchr/testify v1.3.0
+	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
 	golang.org/x/sys v0.0.0-20190311071201-10058d7d4faa // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,14 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
+github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -62,6 +68,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e h1:IWllFTiDjjLIf2oeKxpIUmtiDV5sn71VgeQgg6vcE7k=
+github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e/go.mod h1:d7u6HkTYKSv5m6MCKkOQlHwaShTMl3HjqSGW3XtVhXM=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
This PR adds a check for latest release on github when running the `version` command. Will only be executed on binaries built with a `main.version`.  Will also generate a download string based on OS and executable path to update the tool.

```
➜  corectl git:(latest) go build -ldflags "-X main.version=0.2.0" -o corectl main.go
➜  corectl git:(latest) ./corectl version
-------------------------------------------------
Version 0.2.0 is not latest, you should upgrade to 0.4.0 
To download the latest version you can use this command: 
'curl --silent --location "https://github.com/qlik-oss/corectl/releases/download/v0.4.0/corectl-darwin-x86_64.tar.gz" | tar xz -C /tmp && mv /tmp/corectl /Users/mow/gits/qlik-oss/corectl'
-------------------------------------------------
corectl version: 0.2.0
```

This closes #48 