### PR TITLE
Fix for being unable to set user and password for a connection in config

### DIFF
--- a/internal/connections.go
+++ b/internal/connections.go
@@ -41,24 +41,19 @@ func SetupConnections(ctx context.Context, doc *enigma.Doc, separateConnectionsF
 	connections, err := doc.GetConnections(ctx)
 
 	for name, configEntry := range connectionConfigEntries {
-		var connection *enigma.Connection
-		if configEntry.ConnectionString != "" {
-			connection = &enigma.Connection{
-				Name:             name,
-				Type:             configEntry.Type,
-				UserName:         "",
-				Password:         "",
-				ConnectionString: configEntry.ConnectionString,
-			}
-		} else {
-			connection = &enigma.Connection{
-				Name:             name,
-				Type:             configEntry.Type,
-				UserName:         configEntry.Username,
-				Password:         configEntry.Password,
-				ConnectionString: "CUSTOM CONNECT TO \"provider=" + configEntry.Type + ";" + flattenSettings(configEntry.Settings) + "\"",
-			}
+		var connection = &enigma.Connection{
+			Name:     name,
+			Type:     configEntry.Type,
+			UserName: configEntry.Username,
+			Password: configEntry.Password,
 		}
+
+		if configEntry.ConnectionString != "" {
+			connection.ConnectionString = configEntry.ConnectionString
+		} else {
+			connection.ConnectionString = "CUSTOM CONNECT TO \"provider=" + configEntry.Type + ";" + flattenSettings(configEntry.Settings) + "\""
+		}
+
 		if strings.HasPrefix(connection.Password, "${") && strings.HasSuffix(connection.Password, "}") {
 			varName := strings.TrimSuffix(strings.TrimPrefix(connection.Password, "${"), "}")
 			connection.Password = os.Getenv(varName)


### PR DESCRIPTION
If a connection string was set in a config it was not possible to configure a user or password. It should be up to the engine to validate the connection parameters being passed in.