### PR TITLE
Append semicolon when flattening settings for a connection

### DIFF
--- a/docs/corectl_config.md
+++ b/docs/corectl_config.md
@@ -72,7 +72,8 @@ myfolderconnection:
 
 Depending on which type of connection that should be used there may be a need for additional values in your configuration. Below is another example where we configure an connection to a custom type connection e.g. a gRPC data connector. 
 
-When not specifying a `connectionstring` in your connection `corectl` build a one using the `type`, keys and values from the `settings` property. The exampe below will yield `CUSTOM CONNECT TO \"provider=testconnector;host=corectl-test-connector;\"`.
+When not specifying a `connectionstring` in your connection config then `corectl` builds one for you.
+The value for the `type` property will be set as `provider`, and the keys and values from the `settings` property will also be appended to the `connectionstring`. The example below will yield `CUSTOM CONNECT TO \"provider=testconnector;host=corectl-test-connector;\"`.
 
 ```yaml
 myconnection:

--- a/docs/corectl_config.md
+++ b/docs/corectl_config.md
@@ -70,7 +70,9 @@ myfolderconnection:
     type: folder
 ```
 
-Depending on which type of connection that should be used there may be a need for additional values in your configuration. Below is another example where we configure an connection to a custom type connection e.g. a gRPC data connector.
+Depending on which type of connection that should be used there may be a need for additional values in your configuration. Below is another example where we configure an connection to a custom type connection e.g. a gRPC data connector. 
+
+When not specifying a `connectionstring` in your connection `corectl` build a one using the `type`, keys and values from the `settings` property. The exampe below will yield `CUSTOM CONNECT TO \"provider=testconnector;host=corectl-test-connector;\"`.
 
 ```yaml
 myconnection:

--- a/internal/connections.go
+++ b/internal/connections.go
@@ -12,10 +12,7 @@ import (
 func flattenSettings(settings map[string]string) string {
 	result := ""
 	for name, value := range settings {
-		if result != "" {
-			result += ";"
-		}
-		result += name + "=" + value
+		result += name + "=" + value + ";"
 	}
 	return result
 }


### PR DESCRIPTION
Earlier we did not append a semicolon at the end of a `connectionstring` when appending settings. This led to reload errors when e.g. using custom connectors. Also added some additional documentation regarding how the `settings` can be used.

This closes #167 