### PR TITLE
Handle filenames with spaces during autocompletion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -249,10 +249,10 @@ const bashCompletionFunc = `
     echo "$result";
 	}
 
-  __corect_render_compreply()
+  __corectl_render_compreply()
   {
 		if [[ $? -eq 0 ]]; then
-				COMPREPLY+=( $( compgen -W "$1" -- "$cur" ) )
+				COMPREPLY+=( "${1[@]}" )
 		else 
 				COMPREPLY+=( $( compgen -W "" -- "$cur" ) )
 		fi
@@ -262,34 +262,34 @@ const bashCompletionFunc = `
 	{
 		local flags=$(__extract_flags_to_forward ${words[@]})
 		local corectl_out=$(corectl get dimensions --bash $flags 2>/dev/null)
-		__corect_render_compreply "${corectl_out[*]}"
+		__corectl_render_compreply "${corectl_out[*]}"
 	}
 
 	__corectl_get_measures()
 	{
 		local flags=$(__extract_flags_to_forward ${words[@]})
 		local corectl_out=$(corectl get measures --bash $flags 2>/dev/null)
-		__corect_render_compreply "${corectl_out[*]}"
+		__corectl_render_compreply "${corectl_out[*]}"
 	}
 
 	__corectl_get_objects()
 	{
 		local flags=$(__extract_flags_to_forward ${words[@]})
 		local corectl_out=$(corectl get objects --bash $flags 2>/dev/null) 
-		__corect_render_compreply "${corectl_out[*]}"
+		__corectl_render_compreply "${corectl_out[*]}"
 	}
 
 	__corectl_get_connections()
 	{
 		local flags=$(__extract_flags_to_forward ${words[@]})
 		local corectl_out=$(corectl get connections --bash $flags 2>/dev/null)
-		__corect_render_compreply "${corectl_out[*]}"
+		__corectl_render_compreply "${corectl_out[*]}"
 	}
 
 	__corectl_get_apps()
 	{
 		local config=$(__extract_flags_to_forward ${words[@]})
 		local corectl_out=$(corectl get apps --bash $config 2>/dev/null) 
-		__corect_render_compreply "${corectl_out[*]}"
+		__corectl_render_compreply "${corectl_out[*]}"
 	}
 `

--- a/printer/apps.go
+++ b/printer/apps.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/qlik-oss/corectl/internal"
@@ -21,7 +22,7 @@ func PrintApps(docList []*enigma.DocListEntry, printAsJSON bool, printAsBash boo
 		fmt.Println(prettyJSON(buffer))
 	} else if printAsBash {
 		for _, app := range docList {
-			fmt.Println(app.DocName)
+			PrintToBashComp(app.DocName)
 		}
 	} else {
 		docTable := tm.NewTable(0, 10, 3, ' ', 0)
@@ -70,4 +71,14 @@ func serialTimeToString(filetime enigma.Float64) time.Time {
 	unix := (filetime - 25569) * 86400
 	timestamp := time.Unix(int64(unix), 0).UTC()
 	return timestamp
+}
+
+// PrintToBashComp handles strings that should be included as options when using auto completion
+func PrintToBashComp(str string) {
+	if strings.Contains(str, " ") {
+		// If string includes whitespaces we need to add quotes
+		fmt.Printf("%q\n", str)
+	} else {
+		fmt.Println(str)
+	}
 }

--- a/printer/connections.go
+++ b/printer/connections.go
@@ -15,7 +15,7 @@ func PrintConnections(connections []*enigma.Connection, printAsJSON bool, printA
 		jsonPrinter(connections)
 	} else if printAsBash {
 		for _, connection := range connections {
-			fmt.Println(connection.Id)
+			PrintToBashComp(connection.Id)
 		}
 	} else {
 		connectionsTable := tm.NewTable(0, 10, 3, ' ', 0)

--- a/printer/entities.go
+++ b/printer/entities.go
@@ -29,7 +29,7 @@ func PrintGenericEntities(allInfos []*enigma.NxInfo, entityType string, printAsJ
 	} else if printAsBash {
 		for _, info := range allInfos {
 			if (entityType == "object" && info.Type != "measure" && info.Type != "dimension") || entityType == info.Type {
-				fmt.Println(info.Id)
+				PrintToBashComp(info.Id)
 			}
 		}
 	} else {


### PR DESCRIPTION
`compgen` did not handle filenames containing whitespaces very well, so we will set the `COMPREPLY`directly. We also need to quote all strings that contains a whitespace.

Related to #170 