### PR TITLE
Persist known app IDs to support creation of apps when using ABAC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
             # Spin up environment
             ACCEPT_EULA=yes docker-compose -f ./test/docker-compose.yml up -d
             ENGINE_1_CONTAINER_ID=$(docker ps -aqf "name=engine-1")
+            ENGINE_3_CONTAINER_ID=$(docker ps -aqf "name=engine-3")
             TEST_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' "$ENGINE_1_CONTAINER_ID")
             # Start a container for test execution
             TEST_CONTAINER=$(docker run -e TEST_HOST=$TEST_HOST -d golang:1.12-alpine tail -f /dev/null)
@@ -43,12 +44,14 @@ jobs:
             # Copy code into container
             docker cp /go/pkg $TEST_CONTAINER:/go/pkg
             docker cp . $TEST_CONTAINER:/corectl
-            # Copy apps and data into the first engine container, the second one does not need it.
+            # Copy apps and data into the first engine container, the second one does not need it. Third engine container needs the data and the rules.
             chmod -R 777 ./test/
             docker cp ./test/apps/ $ENGINE_1_CONTAINER_ID:/
             docker cp ./test/data/ $ENGINE_1_CONTAINER_ID:/
+            docker cp ./test/data/ $ENGINE_3_CONTAINER_ID:/
+            docker cp ./test/rules/ $ENGINE_3_CONTAINER_ID:/
             # Execute tests
-            docker exec $TEST_CONTAINER /bin/bash -c 'cd /corectl && go test ./test/corectl_integration_test.go --engineIP $TEST_HOST:9076 --engine2IP $TEST_HOST:9176'
+            docker exec $TEST_CONTAINER /bin/bash -c 'cd /corectl && go test ./test/corectl_integration_test.go --engineIP $TEST_HOST:9076 --engine2IP $TEST_HOST:9176 --engine3IP $TEST_HOST:9276'
 
   publish:
     working_directory: ~/corectl

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -74,7 +74,7 @@ corectl get connections --json`,
 	},
 
 	Run: func(ccmd *cobra.Command, args []string) {
-		state := internal.PrepareEngineState(rootCtx, headers, true)
+		state := internal.PrepareEngineState(rootCtx, headers, false)
 		connections, err := state.Doc.GetConnections(rootCtx)
 		if err != nil {
 			internal.FatalError(err)
@@ -99,7 +99,7 @@ var getConnectionCmd = &cobra.Command{
 			ccmd.Usage()
 			os.Exit(1)
 		}
-		state := internal.PrepareEngineState(rootCtx, headers, true)
+		state := internal.PrepareEngineState(rootCtx, headers, false)
 		connection, err := state.Doc.GetConnection(rootCtx, args[0])
 		if err != nil {
 			internal.FatalError(err)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -79,7 +79,7 @@ corectl remove connections ID-1 ID-2`,
 				internal.FatalError("Failed to remove connection: ", connection, " with error: ", err.Error())
 			}
 		}
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},
@@ -113,7 +113,7 @@ corectl remove dimensions ID-1 ID-2`,
 				internal.FatalError("Failed to remove generic dimension ", entity)
 			}
 		}
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},
@@ -147,7 +147,7 @@ corectl remove measures ID-1 ID-2`,
 				internal.FatalError("Failed to remove generic measure ", entity)
 			}
 		}
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},
@@ -181,7 +181,7 @@ corectl remove objects ID-1 ID-2`,
 				internal.FatalError("Failed to remove generic object ", entity)
 			}
 		}
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -72,15 +72,15 @@ corectl remove connections ID-1 ID-2`,
 			os.Exit(1)
 		}
 
-		state := internal.PrepareEngineState(rootCtx, headers, true)
+		state := internal.PrepareEngineState(rootCtx, headers, false)
 		for _, connection := range args {
 			err := state.Doc.DeleteConnection(rootCtx, connection)
 			if err != nil {
 				internal.FatalError("Failed to remove connection: ", connection, " with error: ", err.Error())
 			}
 		}
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -113,8 +113,8 @@ corectl remove dimensions ID-1 ID-2`,
 				internal.FatalError("Failed to remove generic dimension ", entity)
 			}
 		}
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -147,8 +147,8 @@ corectl remove measures ID-1 ID-2`,
 				internal.FatalError("Failed to remove generic measure ", entity)
 			}
 		}
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -181,8 +181,8 @@ corectl remove objects ID-1 ID-2`,
 				internal.FatalError("Failed to remove generic object ", entity)
 			}
 		}
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -51,7 +51,7 @@ corectl set all --app=my-app.qvf`,
 			internal.SetScript(rootCtx, state.Doc, scriptFile)
 		}
 
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},
@@ -78,7 +78,7 @@ var setConnectionsCmd = &cobra.Command{
 			separateConnectionsFile = GetRelativeParameter("connections")
 		}
 		internal.SetupConnections(rootCtx, state.Doc, separateConnectionsFile, viper.ConfigFileUsed())
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},
@@ -102,7 +102,7 @@ var setDimensionsCmd = &cobra.Command{
 		}
 		state := internal.PrepareEngineState(rootCtx, headers, true)
 		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineDimensions, "dimension")
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},
@@ -126,7 +126,7 @@ var setMeasuresCmd = &cobra.Command{
 		}
 		state := internal.PrepareEngineState(rootCtx, headers, true)
 		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineMeasures, "measure")
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},
@@ -152,7 +152,7 @@ The JSON objects can be in either the GenericObjectProperties format or the Gene
 
 		state := internal.PrepareEngineState(rootCtx, headers, true)
 		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineObjects, "object")
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},
@@ -185,7 +185,7 @@ var setScriptCmd = &cobra.Command{
 			ccmd.Usage()
 			os.Exit(1)
 		}
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -51,8 +51,8 @@ corectl set all --app=my-app.qvf`,
 			internal.SetScript(rootCtx, state.Doc, scriptFile)
 		}
 
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -78,8 +78,8 @@ var setConnectionsCmd = &cobra.Command{
 			separateConnectionsFile = GetRelativeParameter("connections")
 		}
 		internal.SetupConnections(rootCtx, state.Doc, separateConnectionsFile, viper.ConfigFileUsed())
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -102,8 +102,8 @@ var setDimensionsCmd = &cobra.Command{
 		}
 		state := internal.PrepareEngineState(rootCtx, headers, true)
 		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineDimensions, "dimension")
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -126,8 +126,8 @@ var setMeasuresCmd = &cobra.Command{
 		}
 		state := internal.PrepareEngineState(rootCtx, headers, true)
 		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineMeasures, "measure")
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -152,8 +152,8 @@ The JSON objects can be in either the GenericObjectProperties format or the Gene
 
 		state := internal.PrepareEngineState(rootCtx, headers, true)
 		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineObjects, "object")
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -185,8 +185,8 @@ var setScriptCmd = &cobra.Command{
 			ccmd.Usage()
 			os.Exit(1)
 		}
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -96,8 +96,8 @@ var reloadCmd = &cobra.Command{
 
 		internal.Reload(rootCtx, state.Doc, state.Global, silent, true)
 
-		if state.AppID != "" && !viper.GetBool("no-save") {
-			internal.Save(rootCtx, state.Doc, state.AppID)
+		if state.AppName != "" && !viper.GetBool("no-save") {
+			internal.Save(rootCtx, state.Doc)
 		}
 	},
 }
@@ -191,8 +191,8 @@ func build(ccmd *cobra.Command, args []string) {
 
 	internal.Reload(ctx, state.Doc, state.Global, silent, true)
 
-	if state.AppID != "" {
-		internal.Save(ctx, state.Doc, state.AppID)
+	if state.AppName != "" {
+		internal.Save(ctx, state.Doc)
 	}
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -96,7 +96,7 @@ var reloadCmd = &cobra.Command{
 
 		internal.Reload(rootCtx, state.Doc, state.Global, silent, true)
 
-		if state.AppName != "" && !viper.GetBool("no-save") {
+		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}
 	},

--- a/internal/knownapps.go
+++ b/internal/knownapps.go
@@ -1,0 +1,104 @@
+package internal
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"runtime"
+
+	"gopkg.in/yaml.v2"
+)
+
+var knownAppsFilePath = path.Join(userHomeDir(), ".corectl", "knownApps.yml")
+
+// Fetch a matching app id from known apps for a specified app name
+// If not found return the appName and found bool set to false
+func applyNameToIDTransformation(engineURL string, appName string) (appID string, found bool) {
+	apps := getKnownApps()
+
+	if apps == nil {
+		LogVerbose("knownApps yaml file not found")
+		return appName, false
+	}
+
+	if id, ok := apps[engineURL][appName]; ok {
+		LogVerbose("Found id: " + id + " for app with name: " + appName + " @" + engineURL)
+		return id, true
+	}
+
+	LogVerbose("No id found for app with name: " + appName)
+	return appName, false
+}
+
+// Get map of known apps
+func getKnownApps() map[string]map[string]string {
+	var knownApps = map[string]map[string]string{}
+	yamlFile, err := ioutil.ReadFile(knownAppsFilePath)
+	if err != nil {
+		return nil
+	}
+	err = yaml.Unmarshal(yamlFile, &knownApps)
+	if err != nil {
+		FatalError("Failed to unmarshal content of knownApps yaml file: " + err.Error())
+	}
+
+	return knownApps
+}
+
+// Add an app or remove an app from known apps
+func setAppIDToKnownApps(engineURL string, appName string, appID string, remove bool) {
+
+	createKnownAppsFileIfNotExist()
+	apps := getKnownApps()
+
+	// Either remove or add an entry
+	if remove {
+		_, exists := apps[engineURL][appName]
+		if exists {
+			delete(apps[engineURL], appName)
+			LogVerbose("Removed app with name: " + appName + " and id: " + appID + " @" + engineURL + " from known apps")
+		}
+	} else {
+		if apps[engineURL] == nil {
+			apps[engineURL] = make(map[string]string)
+		}
+		apps[engineURL][appName] = appID
+		LogVerbose("Added app with name: " + appName + " and id: " + appID + " @" + engineURL + " to known apps")
+	}
+
+	// Write to knownApps.yml
+	out, _ := yaml.Marshal(apps)
+	_ = ioutil.WriteFile(knownAppsFilePath, out, 0644)
+}
+
+// Create a knownApps.yml if one does not exist
+func createKnownAppsFileIfNotExist() {
+	if _, err := os.Stat(knownAppsFilePath); os.IsNotExist(err) {
+
+		// Create .corectl folder in home directory
+		err = os.Mkdir(path.Join(userHomeDir(), ".corectl"), os.ModePerm)
+		if err != nil {
+			FatalError("Failed to create .corectl folder in home directory: " + err.Error())
+		}
+
+		// Create knownApps.yml in .corectl folder
+		_, err := os.Create(knownAppsFilePath)
+		if err != nil {
+			FatalError("Failed to create knownApps.yml in .corectl folder: " + err.Error())
+		}
+
+		LogVerbose("Created ~/.corectl/knownApps.yml for storage of app ids")
+	}
+}
+
+// Get the user home directory dependent on OS
+func userHomeDir() string {
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+		return home
+	}
+	return os.Getenv("HOME")
+}

--- a/internal/knownapps.go
+++ b/internal/knownapps.go
@@ -21,7 +21,7 @@ func applyNameToIDTransformation(engineURL string, appName string) (appID string
 		return appName, false
 	}
 
-	if id, ok := apps[engineURL][appName]; ok {
+	if id, exists := apps[engineURL][appName]; exists {
 		LogVerbose("Found id: " + id + " for app with name: " + appName + " @" + engineURL)
 		return id, true
 	}
@@ -53,14 +53,13 @@ func setAppIDToKnownApps(engineURL string, appName string, appID string, remove 
 
 	// Either remove or add an entry
 	if remove {
-		_, exists := apps[engineURL][appName]
-		if exists {
+		if _, exists := apps[engineURL][appName]; exists {
 			delete(apps[engineURL], appName)
 			LogVerbose("Removed app with name: " + appName + " and id: " + appID + " @" + engineURL + " from known apps")
 		}
 	} else {
 		if apps[engineURL] == nil {
-			apps[engineURL] = make(map[string]string)
+			apps[engineURL] = map[string]string{}
 		}
 		apps[engineURL][appName] = appID
 		LogVerbose("Added app with name: " + appName + " and id: " + appID + " @" + engineURL + " to known apps")
@@ -68,7 +67,10 @@ func setAppIDToKnownApps(engineURL string, appName string, appID string, remove 
 
 	// Write to knownApps.yml
 	out, _ := yaml.Marshal(apps)
-	_ = ioutil.WriteFile(knownAppsFilePath, out, 0644)
+
+	if err := ioutil.WriteFile(knownAppsFilePath, out, 0644); err != nil {
+		FatalError("Failed to write to knownApps.yml: " + err.Error())
+	}
 }
 
 // Create a knownApps.yml if one does not exist

--- a/internal/reload.go
+++ b/internal/reload.go
@@ -81,9 +81,9 @@ func logProgress(ctx context.Context, global *enigma.Global, reservedRequestID i
 }
 
 // Save calls DoSave on the app and prints "Done" if it succeeded or "Save failed" to system out.
-func Save(ctx context.Context, doc *enigma.Doc, path string) {
+func Save(ctx context.Context, doc *enigma.Doc) {
 	fmt.Print("Saving app... ")
-	err := doc.DoSave(ctx, path)
+	err := doc.DoSave(ctx, "")
 	if err == nil {
 		fmt.Println("Done")
 	} else {

--- a/printer/status.go
+++ b/printer/status.go
@@ -11,8 +11,8 @@ import (
 //PrintStatus prints the name of the app and the engine corectl is connected to.
 // It also prints if the data model is empty or not
 func PrintStatus(state *internal.State, engine string) {
-	if state.AppID != "" {
-		fmt.Println("Connected to " + state.AppID + " @ " + engine)
+	if state.AppName != "" {
+		fmt.Println("Connected to " + state.AppName + " @ " + engine)
 	} else {
 		fmt.Println("Connected to session app @ " + engine)
 	}

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -22,8 +22,9 @@ import (
 
 var update = flag.Bool("update", true, "update golden files")
 
-var engineIP = flag.String("engineIP", "localhost:9076", "dir of package containing embedded files")
-var engine2IP = flag.String("engine2IP", "localhost:9176", "dir of package containing embedded files")
+var engineIP = flag.String("engineIP", "localhost:9076", "URL to first engine instance in docker-compose.yml i.e qix-engine-1")
+var engine2IP = flag.String("engine2IP", "localhost:9176", "URL to second engine instance in docker-compose.yml i.e qix-engine-2")
+var engine3IP = flag.String("engine3IP", "localhost:9276", "URL to third engine instance in docker-compose.yml i.e qix-engine-3")
 
 func getBinaryName() string {
 	if runtime.GOOS == "windows" {
@@ -193,6 +194,7 @@ type test struct {
 func TestCorectl(t *testing.T) {
 	connectToEngine := "--engine=" + *engineIP
 	connectToEngineWithInccorectLicenseService := "--engine=" + *engine2IP
+	connectToEngineABAC := "--engine=" + *engine3IP
 
 	// General
 	emptyConnectString := []string{}
@@ -236,6 +238,7 @@ func TestCorectl(t *testing.T) {
 		// Project 2 has separate connections file
 		{"project 2 - build with connections", []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0"}, []string{"build", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, []string{"datacsv << data 1 Lines fetched", "Reload finished successfully", "Saving app... Done"}, initTest{false, true}},
 		{"project 2 - build with connections 2", []string{connectToEngine, "--config=test/project2/corectl-connectionsref.yml"}, []string{"build"}, []string{"datacsv << data 1 Lines fetched", "Reload finished successfully", "Saving app... Done"}, initTest{false, true}},
+		{"project 2 - get fields ", []string{"--config=test/project2/corectl-alt.yml ", connectToEngine}, []string{"get", "fields"}, []string{"golden", "project2-fields.golden"}, initTest{true, true}},
 		{"project 2 - get data", []string{"--config=test/project2/corectl-alt.yml ", connectToEngine}, []string{"get", "object", "data", "my-hypercube-on-commandline"}, []string{"golden", "project2-data.golden"}, initTest{true, true}},
 
 		{"project 3 - build ", defaultConnectString3, []string{"build"}, []string{"No app specified, using session app.", "datacsv << data 1 Lines fetched", "Reload finished successfully"}, initTest{false, false}},
@@ -252,6 +255,11 @@ func TestCorectl(t *testing.T) {
 		// trying to connect to an engine that has JWT authorization activated without a JWT Header
 		{"err jwt", []string{connectToEngine}, []string{"get", "apps"}, []string{"Error details:  401 from ws server: websocket: bad handshake"}, initTest{false, false}},
 		{"err no license", []string{connectToEngineWithInccorectLicenseService}, []string{"get", "apps"}, []string{"Failed to connect to engine with error message:  SESSION_ERROR_NO_LICENSE"}, initTest{false, false}},
+
+		// Verifying corectl against an engine running with ABAC enabled
+		{"project 4 - get status", []string{"--config=test/project4/corectl.yml ", connectToEngineABAC}, []string{"get", "status"}, []string{"Connected to project4.qvf @ ", "The data model has 1 tables."}, initTest{true, true}},
+		{"project 4 - list apps", []string{"--config=test/project4/corectl.yml ", connectToEngineABAC}, []string{"get", "apps"}, []string{"Id", "Name", "Last-Reloaded", "ReadOnly", "Title", "project4.qvf"}, initTest{true, true}},
+		{"project 4 - get meta", []string{"--config=test/project4/corectl.yml ", connectToEngineABAC}, []string{"get", "meta"}, []string{"golden", "project4-meta.golden"}, initTest{true, true}},
 	}
 
 	for _, tt := range tests {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,6 +15,15 @@ services:
     ports:
       - 9176:9076
     command: -S AcceptEULA=${ACCEPT_EULA}  -S SystemLogVerbosity=5 -S LicenseServiceUrl="doesnotexit:9090"
+  qix-engine-3:
+    container_name: qix-engine-3
+    image: qlikcore/engine:12.345.0
+    ports:
+      - 9276:9076
+    command: -S AcceptEULA=${ACCEPT_EULA}  -S DocumentDirectory=/apps -S EnableABAC=1 -S SystemAllowRulePath=/rules/rules.txt
+    volumes:
+      - ./data:/data
+      - ./rules:/rules
   corectl-test-connector:
     container_name: corectl-test-connector
     build: testconnector

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: qlikcore/engine:12.345.0
     ports:
       - 9276:9076
-    command: -S AcceptEULA=${ACCEPT_EULA}  -S DocumentDirectory=/apps -S EnableABAC=1 -S SystemAllowRulePath=/rules/rules.txt
+    command: -S AcceptEULA=${ACCEPT_EULA} -S EnableABAC=1 -S SystemAllowRulePath=/rules/rules.txt
     volumes:
       - ./data:/data
       - ./rules:/rules

--- a/test/golden/project4-meta.golden
+++ b/test/golden/project4-meta.golden
@@ -1,0 +1,15 @@
+---------- Fields ----------
+Field        Uniq/Tot   RAM   Tags                 datacsv   Sample content
+a            1          11    $numeric, $integer   1/1       1   
+b            1          11    $numeric, $integer   1/1       2   
+c            1          11    $numeric, $integer   1/1       3   
+                                                   
+Total RAM               152                        0
+
+---------- Tables ----------
+Name         Row count   RAM   Fields
+datacsv      1           0     a, b, c
+                         
+Total RAM                152
+---------- Associations ----------
+Field(s)   Linked tables

--- a/test/project4/corectl.yml
+++ b/test/project4/corectl.yml
@@ -1,0 +1,7 @@
+engine: localhost:9276
+app: project4.qvf
+script: ./script.qvs
+connections:
+  testdata:
+    connectionstring: /data
+    type: folder

--- a/test/project4/script.qvs
+++ b/test/project4/script.qvs
@@ -1,0 +1,5 @@
+datacsv:
+LOAD
+  *
+FROM [lib://testdata/data.csv]
+(txt, utf8, embedded labels, delimiter is ',');

--- a/test/rules/rules.txt
+++ b/test/rules/rules.txt
@@ -1,0 +1,1 @@
+resource._actions = {"*"}


### PR DESCRIPTION
This PR adds persisting of app IDs when creating apps using `corectl`. When using an engine with ABAC we should use the app ID when opening a session to an app, and not the app name. If an id does not exist in the knownApps file we assume that appID = appName.

Also changed so only `build` and `set` commands actually creates an app, if one does not already exist.

This closes #178 