### PR TITLE
Add possibility to open app without data

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,6 +96,9 @@ func init() {
 	rootCmd.PersistentFlags().String("ttl", "30", "Qlik Associative Engine session time to live in seconds")
 	viper.BindPFlag("ttl", rootCmd.PersistentFlags().Lookup("ttl"))
 
+	rootCmd.PersistentFlags().Bool("no-data", false, "Open app without data")
+	viper.BindPFlag("no-data", rootCmd.PersistentFlags().Lookup("no-data"))
+
 	rootCmd.PersistentFlags().Bool("bash", false, "Bash flag used to adapt output to bash completion format")
 	rootCmd.PersistentFlags().MarkHidden("bash")
 	viper.BindPFlag("bash", rootCmd.PersistentFlags().Lookup("bash"))

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -18,6 +18,7 @@ corectl [flags]
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -35,6 +35,7 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -31,6 +31,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_completion.md
+++ b/docs/corectl_completion.md
@@ -37,6 +37,7 @@ corectl completion <shell> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -32,6 +32,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get.md
+++ b/docs/corectl_get.md
@@ -19,6 +19,7 @@ Lists one or several resources
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_apps.md
+++ b/docs/corectl_get_apps.md
@@ -31,6 +31,7 @@ corectl get apps --engine=localhost:9276
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_assoc.md
+++ b/docs/corectl_get_assoc.md
@@ -30,6 +30,7 @@ corectl get associations
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_connection.md
+++ b/docs/corectl_get_connection.md
@@ -29,6 +29,7 @@ corectl get connection CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_connections.md
+++ b/docs/corectl_get_connections.md
@@ -31,6 +31,7 @@ corectl get connections --json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_dimension.md
+++ b/docs/corectl_get_dimension.md
@@ -29,6 +29,7 @@ corectl get dimension DIMENSION-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_dimension_layout.md
+++ b/docs/corectl_get_dimension_layout.md
@@ -29,6 +29,7 @@ corectl get dimension layout DIMENSION-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_dimension_properties.md
+++ b/docs/corectl_get_dimension_properties.md
@@ -29,6 +29,7 @@ corectl get dimension properties DIMENSION-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_dimensions.md
+++ b/docs/corectl_get_dimensions.md
@@ -30,6 +30,7 @@ corectl get dimensions
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_field.md
+++ b/docs/corectl_get_field.md
@@ -29,6 +29,7 @@ corectl get field FIELD
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_fields.md
+++ b/docs/corectl_get_fields.md
@@ -29,6 +29,7 @@ corectl get fields
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_keys.md
+++ b/docs/corectl_get_keys.md
@@ -29,6 +29,7 @@ corectl get keys
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_measure.md
+++ b/docs/corectl_get_measure.md
@@ -29,6 +29,7 @@ corectl get measure MEASURE-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_measure_layout.md
+++ b/docs/corectl_get_measure_layout.md
@@ -30,6 +30,7 @@ corectl get measure layout MEASURE-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_measure_properties.md
+++ b/docs/corectl_get_measure_properties.md
@@ -30,6 +30,7 @@ corectl get measure properties MEASURE-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_measures.md
+++ b/docs/corectl_get_measures.md
@@ -31,6 +31,7 @@ corectl get measures --json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_meta.md
+++ b/docs/corectl_get_meta.md
@@ -30,6 +30,7 @@ corectl get meta --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_object.md
+++ b/docs/corectl_get_object.md
@@ -29,6 +29,7 @@ corectl get object OBJECT-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_object_data.md
+++ b/docs/corectl_get_object_data.md
@@ -29,6 +29,7 @@ corectl get object data OBJECT-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_object_layout.md
+++ b/docs/corectl_get_object_layout.md
@@ -29,6 +29,7 @@ corectl get object layout OBJECT-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_object_properties.md
+++ b/docs/corectl_get_object_properties.md
@@ -29,6 +29,7 @@ corectl get object properties OBJECT-ID --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_objects.md
+++ b/docs/corectl_get_objects.md
@@ -31,6 +31,7 @@ corectl get objects --json --app=myapp.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_script.md
+++ b/docs/corectl_get_script.md
@@ -30,6 +30,7 @@ corectl get script --app=my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_status.md
+++ b/docs/corectl_get_status.md
@@ -30,6 +30,7 @@ corectl get status --app=my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_get_tables.md
+++ b/docs/corectl_get_tables.md
@@ -30,6 +30,7 @@ corectl get tables --app=my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -31,6 +31,7 @@ corectl reload
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_remove.md
+++ b/docs/corectl_remove.md
@@ -20,6 +20,7 @@ Remove one or mores generic entities (connections, dimensions, measures, objects
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_remove_app.md
+++ b/docs/corectl_remove_app.md
@@ -29,6 +29,7 @@ corectl remove app APP-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_remove_connection.md
+++ b/docs/corectl_remove_connection.md
@@ -31,6 +31,7 @@ corectl remove connections ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_remove_dimension.md
+++ b/docs/corectl_remove_dimension.md
@@ -31,6 +31,7 @@ corectl remove dimensions ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_remove_measure.md
+++ b/docs/corectl_remove_measure.md
@@ -31,6 +31,7 @@ corectl remove measures ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_remove_object.md
+++ b/docs/corectl_remove_object.md
@@ -31,6 +31,7 @@ corectl remove objects ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --suppress                 Suppress all confirmation dialogues
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_set.md
+++ b/docs/corectl_set.md
@@ -20,6 +20,7 @@ Sets one or several resources
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/corectl_set_all.md
+++ b/docs/corectl_set_all.md
@@ -35,6 +35,7 @@ corectl set all --app=my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_connections.md
+++ b/docs/corectl_set_connections.md
@@ -29,6 +29,7 @@ corectl set connections ./my-connections.yml
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_dimensions.md
+++ b/docs/corectl_set_dimensions.md
@@ -29,6 +29,7 @@ corectl set dimensions ./my-dimensions-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_measures.md
+++ b/docs/corectl_set_measures.md
@@ -29,6 +29,7 @@ corectl set measures ./my-measures-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_objects.md
+++ b/docs/corectl_set_objects.md
@@ -30,6 +30,7 @@ corectl set objects ./my-objects-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_set_script.md
+++ b/docs/corectl_set_script.md
@@ -29,6 +29,7 @@ corectl set script ./my-script-file
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
       --no-save                  Do not save the app
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -29,6 +29,7 @@ corectl version
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -30,6 +30,10 @@
       "description": "Http headers to use when connecting to Qlik Associative Engine",
       "default": "[]"
     },
+    "no-data": {
+      "description": "Open app without data",
+      "default": "false"
+    },
     "traffic": {
       "alias": "t",
       "description": "Log JSON websocket traffic to stdout",

--- a/internal/reload.go
+++ b/internal/reload.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/qlik-oss/enigma-go"
+	"github.com/spf13/viper"
 )
 
 // Reload reloads the app and prints the progress to system out. If true is supplied to skipTransientLogs
@@ -82,8 +83,17 @@ func logProgress(ctx context.Context, global *enigma.Global, reservedRequestID i
 
 // Save calls DoSave on the app and prints "Done" if it succeeded or "Save failed" to system out.
 func Save(ctx context.Context, doc *enigma.Doc) {
-	fmt.Print("Saving app... ")
-	err := doc.DoSave(ctx, "")
+	noData := viper.GetBool("no-data")
+	var err error
+
+	// If app is opened without data we should only save the objects
+	if noData {
+		fmt.Print("Saving objects in app... ")
+		err = doc.SaveObjects(ctx)
+	} else {
+		fmt.Print("Saving app... ")
+		err = doc.DoSave(ctx, "")
+	}
 	if err == nil {
 		fmt.Println("Done")
 	} else {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var update = flag.Bool("update", true, "update golden files")
+var update = flag.Bool("update", false, "update golden files")
 
 var engineIP = flag.String("engineIP", "localhost:9076", "URL to first engine instance in docker-compose.yml i.e qix-engine-1")
 var engine2IP = flag.String("engine2IP", "localhost:9176", "URL to second engine instance in docker-compose.yml i.e qix-engine-2")
@@ -234,6 +234,10 @@ func TestCorectl(t *testing.T) {
 		{"project 1 - set script", defaultConnectString1, []string{"set", "script", "test/project1/dummy-script.qvs", "--no-save"}, []string{"golden", "blank.golden"}, initTest{true, true}},
 		{"project 1 - get script after setting it", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"get", "script"}, []string{"golden", "project1-script-2.golden"}, initTest{true, true}},
 		{"project 1 - traffic logging", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"get", "script", "--traffic"}, []string{"golden", "project1-traffic-log.golden"}, initTest{true, true}},
+
+		// Verify behaviour when opening an app without data
+		{"project 1 - open app without data", []string{"--config=test/project1/corectl-alt.yml", "--ttl", "0", connectToEngine}, []string{"get", "connections", "--no-data", "--verbose"}, []string{"without data"}, initTest{true, true}},
+		{"project 1 - save objects in app opened without data", []string{"--config=test/project1/corectl.yml", "--ttl", "0", connectToEngine}, []string{"build", "--no-data"}, []string{"Saving objects in app... Done"}, initTest{false, true}},
 
 		// Project 2 has separate connections file
 		{"project 2 - build with connections", []string{connectToEngine, "-a=project2.qvf", "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0"}, []string{"build", "--script=test/project2/script.qvs", "--connections=test/project2/connections.yml", "--objects=test/project2/object-*.json"}, []string{"datacsv << data 1 Lines fetched", "Reload finished successfully", "Saving app... Done"}, initTest{false, true}},

--- a/test/golden/help-1.golden
+++ b/test/golden/help-1.golden
@@ -22,6 +22,7 @@ Flags:
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/test/golden/help-2.golden
+++ b/test/golden/help-2.golden
@@ -22,6 +22,7 @@ Flags:
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information

--- a/test/golden/help-3.golden
+++ b/test/golden/help-3.golden
@@ -20,6 +20,7 @@ Global Flags:
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
   -v, --verbose                  Logs extra information


### PR DESCRIPTION
This PR adds a flag `--no-data` that can be used to open an app without data. If the flag is used then only objects will be saved to the app.

When using `--no-data` or the `--ttl` flag then we do not want to attach to an existing session if the values are != default, so I have added the flags to the session id as well.

This closes #163 