### PR TITLE
Suggestion typos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.3.0
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
+	github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e
 	golang.org/x/sys v0.0.0-20190407153405-4b34438f7a67 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e h1:IWllFTiDjjLIf2oeKxpIUmtiDV5sn71VgeQgg6vcE7k=
 github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e/go.mod h1:d7u6HkTYKSv5m6MCKkOQlHwaShTMl3HjqSGW3XtVhXM=
+github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e h1:T5PdfK/M1xyrHwynxMIVMWLS7f/qHwfslZphxtGnw7s=
+github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=

--- a/internal/config.go
+++ b/internal/config.go
@@ -93,7 +93,7 @@ func ReadConfigFile(explicitConfigFile string) {
 	if configFile != "" {
 		LogVerbose("Using config file: " + configFile)
 	} else {
-		LogVerbose("No config file")
+		LogVerbose("No config file specified, using default values.")
 	}
 }
 
@@ -128,13 +128,17 @@ func validateProps(configPath string) {
 	if len(invalidProps) + len(suggestions) > 0 {
 		errorMessage := []string{}
 		errorMessage = append(errorMessage,
-			fmt.Sprintf("Found the following invalid properties when validating the config file '%s':", configPath))
+			fmt.Sprintf("Corectl found invalid properties when validating the config file '%s'.", configPath))
 		for key, value := range suggestions {
 			errorMessage = append(errorMessage, fmt.Sprintf("  '%s': did you mean '%s'?", key, value))
 		}
 		if len(invalidProps) > 0 {
+			prepend := "M" // Capitalize M if there were no suggestions
+			if len(suggestions) > 0 {
+				prepend = "Also, m" // Add also if there were suggestions
+			}
 			errorMessage = append(errorMessage,
-				fmt.Sprintf("Not even corectl can interpret: %s", strings.Join(invalidProps, ", ")))
+				fmt.Sprintf("%systerious properties: %s", prepend, strings.Join(invalidProps, ", ")))
 		}
 		FatalError(strings.Join(errorMessage, "\n"))
 	}
@@ -149,9 +153,12 @@ func findConfigFile(fileName string) string {
 	} else if _, err := os.Stat(fileName + ".yaml"); !os.IsNotExist(err) {
 		configFile = fileName + ".yaml"
 	}
-	configFile, err := filepath.Abs(configFile) // Convert to abs path
-	if err != nil {
-		FatalError(err)
+	if configFile != "" {
+		absConfig, err := filepath.Abs(configFile) // Convert to abs path
+		if err != nil {
+			FatalError(err)
+		}
+		configFile = absConfig
 	}
 	return configFile
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -128,7 +128,7 @@ func validateProps(configPath string) {
 	if len(invalidProps) + len(suggestions) > 0 {
 		errorMessage := []string{}
 		errorMessage = append(errorMessage,
-			fmt.Sprintf("Corectl found invalid properties when validating the config file '%s'.", configPath))
+			fmt.Sprintf("corectl found invalid properties when validating the config file '%s'.", configPath))
 		for key, value := range suggestions {
 			errorMessage = append(errorMessage, fmt.Sprintf("  '%s': did you mean '%s'?", key, value))
 		}

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -267,7 +267,7 @@ func TestCorectl(t *testing.T) {
 
 		// Verifying config validation
 		{"err invalid 1", []string{"--config=test/project3/corectl-invalid.yml ", connectToEngine}, []string{"build"}, []string{"apps", "header", "object", "measure", "verbos", "trafic", "connection", "dimension"}, initTest{false, false}},
-		{"err invalid 2", []string{"--config=test/project3/corectl-invalid2.yml ", connectToEngine}, []string{"build"}, []string{"Found invalid config properties: [header]"}, initTest{false, false}},
+		{"err invalid 2", []string{"--config=test/project3/corectl-invalid2.yml ", connectToEngine}, []string{"build"}, []string{"'header': did you mean 'headers'?", "test/project3/corectl-invalid2.yml"}, initTest{false, false}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Related to the config validation we now provide some feedback in the form of suggestions for property names that are likely typos and more thorough feedback for erroneous configs in general.

Exactly what Levenshtein distance between two words we define as a typo is up for debate. I made the arbitrary choice of distance 4 as limit, using the default option in the Levenshtein library which weighs inserts and deletions as 1 and substitutions as 2.

The feedback also references the yaml's absolute path.


This close the issue #204