### PR TITLE
Unmarshal fix

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -22,10 +22,10 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs`,
 		if separateConnectionsFile == "" {
 			separateConnectionsFile = getPathFlagFromConfigFile("connections")
 		}
-		internal.SetupConnections(ctx, state.Doc, separateConnectionsFile, viper.ConfigFileUsed())
-		internal.SetupEntities(ctx, state.Doc, viper.ConfigFileUsed(), ccmd.Flag("dimensions").Value.String(), "dimension")
-		internal.SetupEntities(ctx, state.Doc, viper.ConfigFileUsed(), ccmd.Flag("measures").Value.String(), "measure")
-		internal.SetupEntities(ctx, state.Doc, viper.ConfigFileUsed(), ccmd.Flag("objects").Value.String(), "object")
+		internal.SetupConnections(ctx, state.Doc, separateConnectionsFile)
+		internal.SetupEntities(ctx, state.Doc, ccmd.Flag("dimensions").Value.String(), "dimension")
+		internal.SetupEntities(ctx, state.Doc, ccmd.Flag("measures").Value.String(), "measure")
+		internal.SetupEntities(ctx, state.Doc, ccmd.Flag("objects").Value.String(), "object")
 		scriptFile := ccmd.Flag("script").Value.String()
 		if scriptFile == "" {
 			scriptFile = getPathFlagFromConfigFile("script")

--- a/cmd/connection.go
+++ b/cmd/connection.go
@@ -25,7 +25,7 @@ corectl connection set ./my-connections.yml`,
 		if separateConnectionsFile == "" {
 			separateConnectionsFile = getPathFlagFromConfigFile("connections")
 		}
-		internal.SetupConnections(rootCtx, state.Doc, separateConnectionsFile, viper.ConfigFileUsed())
+		internal.SetupConnections(rootCtx, state.Doc, separateConnectionsFile)
 		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}

--- a/cmd/dimension.go
+++ b/cmd/dimension.go
@@ -22,7 +22,7 @@ corectl dimension set ./my-dimensions-glob-path.json`,
 			commandLineDimensions = args[0]
 		}
 		state := internal.PrepareEngineState(rootCtx, headers, true)
-		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineDimensions, "dimension")
+		internal.SetupEntities(rootCtx, state.Doc, commandLineDimensions, "dimension")
 		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
+
 	"github.com/qlik-oss/corectl/internal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"runtime"
 )
 
 var localFlags pflag.FlagSet
@@ -17,7 +18,7 @@ var initialized bool
 func getPathFlagFromConfigFile(paramName string) string {
 	pathInConfigFile := viper.GetString(paramName)
 	if pathInConfigFile != "" {
-		return internal.RelativeToProject(viper.ConfigFileUsed(), pathInConfigFile)
+		return internal.RelativeToProject(pathInConfigFile)
 	}
 	return ""
 }

--- a/cmd/measure.go
+++ b/cmd/measure.go
@@ -22,7 +22,7 @@ corectl measure set ./my-measures-glob-path.json`,
 			commandLineMeasures = args[0]
 		}
 		state := internal.PrepareEngineState(rootCtx, headers, true)
-		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineMeasures, "measure")
+		internal.SetupEntities(rootCtx, state.Doc, commandLineMeasures, "measure")
 		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -25,7 +25,7 @@ corectl object set ./my-objects-glob-path.json`,
 		}
 
 		state := internal.PrepareEngineState(rootCtx, headers, true)
-		internal.SetupEntities(rootCtx, state.Doc, viper.ConfigFileUsed(), commandLineObjects, "object")
+		internal.SetupEntities(rootCtx, state.Doc, commandLineObjects, "object")
 		if state.AppID != "" && !viper.GetBool("no-save") {
 			internal.Save(rootCtx, state.Doc)
 		}

--- a/internal/config.go
+++ b/internal/config.go
@@ -24,7 +24,7 @@ type ConnectionConfigEntry struct {
 	Settings         map[string]string
 }
 
-// ConnectionsConfig defines the content of a connections yml file.
+// ConnectionsConfig represents how the connections are configured. 
 type ConnectionsConfig struct {
 	Connections map[string]ConnectionConfigEntry
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -39,16 +39,15 @@ func GetConnectionsConfig() ConnectionsConfig {
 		config = ReadConnectionsFile(connFile)
 	case map[string]interface{}:
 		connMap := conn.(map[string]interface{})
-		fmt.Println(connMap)
 		err := reMarshal(connMap, &config.Connections)
 		if err != nil {
 			FatalError(err)
 		}
 	}
-	fmt.Println(config)
 	return config
 }
 
+// reMarshal takes a map and tries to fit it to a struct
 func reMarshal(m map[string]interface{}, ref interface{}) error {
 	bytes, err := yaml.Marshal(m)
 	if err != nil {

--- a/internal/config.go
+++ b/internal/config.go
@@ -2,14 +2,18 @@ package internal
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
-	leven "github.com/texttheater/golang-levenshtein/levenshtein"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/viper"
+	leven "github.com/texttheater/golang-levenshtein/levenshtein"
+	"gopkg.in/yaml.v2"
 )
+
+// ConfigDir represents the directory of the config file used.
+var ConfigDir string
 
 // ConnectionConfigEntry defines the content of a connection in either the project config yml file or a connections yml file.
 type ConnectionConfigEntry struct {
@@ -20,36 +24,46 @@ type ConnectionConfigEntry struct {
 	Settings         map[string]string
 }
 
-// ConnectionsConfigFile defines the content of a connections yml file.
-type ConnectionsConfigFile struct {
+// ConnectionsConfig defines the content of a connections yml file.
+type ConnectionsConfig struct {
 	Connections map[string]ConnectionConfigEntry
 }
 
-// FileWithReferenceToConfigFile defines a config file with a path reference to an external connections.yml file.
-type FileWithReferenceToConfigFile struct {
-	Connections string
+// GetConnectionsConfig returns a the current connections configuration.
+func GetConnectionsConfig() ConnectionsConfig {
+	var config ConnectionsConfig
+	conn := viper.Get("connections")
+	switch conn.(type) {
+	case string:
+		connFile := RelativeToProject(conn.(string))
+		config = ReadConnectionsFile(connFile)
+	case map[string]interface{}:
+		connMap := conn.(map[string]interface{})
+		fmt.Println(connMap)
+		err := reMarshal(connMap, &config.Connections)
+		if err != nil {
+			FatalError(err)
+		}
+	}
+	fmt.Println(config)
+	return config
 }
 
-func ResolveConnectionsFileReferenceInConfigFile(projectPath string) string {
-	var configFileWithFileReference FileWithReferenceToConfigFile
-	source, err := ioutil.ReadFile(projectPath)
+func reMarshal(m map[string]interface{}, ref interface{}) error {
+	bytes, err := yaml.Marshal(m)
 	if err != nil {
-		return projectPath
+		return err
 	}
-	err = yaml.Unmarshal(source, &configFileWithFileReference)
+	err = yaml.Unmarshal(bytes, ref)
 	if err != nil {
-		return projectPath
+		return err
 	}
-	if configFileWithFileReference.Connections == "" {
-		return projectPath
-	}
-	return RelativeToProject(projectPath, configFileWithFileReference.Connections)
-
+	return nil
 }
 
 // ReadConnectionsFile reads the connections config file from the supplied path.
-func ReadConnectionsFile(path string) ConnectionsConfigFile {
-	var config ConnectionsConfigFile
+func ReadConnectionsFile(path string) ConnectionsConfig {
+	var config ConnectionsConfig
 	source, err := ioutil.ReadFile(path)
 	if err != nil {
 		FatalError("Could not find connections file:", path)
@@ -91,6 +105,7 @@ func ReadConfigFile(explicitConfigFile string) {
 	QliVerbose = viper.GetBool("verbose")
 	LogTraffic = viper.GetBool("traffic")
 	if configFile != "" {
+		ConfigDir = filepath.Dir(configFile)
 		LogVerbose("Using config file: " + configFile)
 	} else {
 		LogVerbose("No config file specified, using default values.")

--- a/internal/connections.go
+++ b/internal/connections.go
@@ -19,16 +19,15 @@ func flattenSettings(settings map[string]string) string {
 
 // SetupConnections reads all connections from both the project file path and the config file path and updates
 // the list of connections in the app.
-func SetupConnections(ctx context.Context, doc *enigma.Doc, separateConnectionsFile string, projectConfigFilePath string) error {
+func SetupConnections(ctx context.Context, doc *enigma.Doc, separateConnectionsFile string) error {
 
-	connectionConfigEntries := make(map[string]ConnectionConfigEntry)
-	if projectConfigFilePath != "" {
+	connectionConfigEntries := map[string]ConnectionConfigEntry{}
+	if ConfigDir != "" {
 
 		//First try to interpret the connections entry in the config file as a path.
 		//If the connections entry is a string it is interpreted as a path pointing to a separate connections file
 		//This is mainly to align with the way the --connections flag on the command line is treated.
-		projectConfigFilePath = ResolveConnectionsFileReferenceInConfigFile(projectConfigFilePath)
-		config := ReadConnectionsFile(projectConfigFilePath)
+		config := GetConnectionsConfig()
 		for name, configEntry := range config.Connections {
 			connectionConfigEntries[name] = configEntry
 		}

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -7,10 +7,9 @@ import (
 )
 
 // RelativeToProject transforms a path to be relative to a base path of the project file
-func RelativeToProject(projectFile string, path string) string {
-	if projectFile != "" && !filepath.IsAbs(path) {
-		projectDir := filepath.Dir(projectFile)
-		fullpath := filepath.Join(projectDir, path)
+func RelativeToProject(path string) string {
+	if ConfigDir != "" && !filepath.IsAbs(path) {
+		fullpath := filepath.Join(ConfigDir, path)
 		return fullpath
 	}
 	return path

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestRelativeToProject(t *testing.T) {
-
-	res := RelativeToProject("/etc/corectl.yml", "./myscript.qvs")
+	ConfigDir = "/etc/"
+	res := RelativeToProject("./myscript.qvs")
 	assert.Equal(t, "/etc/myscript.qvs", strings.Replace(res, string(os.PathSeparator), "/", -1))
 
-	res = RelativeToProject("/etc/corectl.yml", "scripts/myscript.qvs")
+	res = RelativeToProject("scripts/myscript.qvs")
 	assert.Equal(t, "/etc/scripts/myscript.qvs", strings.Replace(res, string(os.PathSeparator), "/", -1))
 
-	res = RelativeToProject("/etc/corectl.yml", "../scripts/myscript.qvs")
+	res = RelativeToProject("../scripts/myscript.qvs")
 	assert.Equal(t, "/scripts/myscript.qvs", strings.Replace(res, string(os.PathSeparator), "/", -1))
 }


### PR DESCRIPTION
Changed so that config information is retrieved from viper instead of use `yaml.Unmarshal` here and there throughout the project.

Main changes are:
- `internal.ConfigDir` stores the directory of the current config file
- The config file is read once
- `internal/config.go` handles the config files

With this change, we will be able to substitute environment variables in config files and work towards resolving: #206 and #197. (There is another PR in the chamber with that enhancement.)