### PR TITLE
Valid properties are now dynamically added

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
+
 	"github.com/qlik-oss/corectl/internal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"runtime"
 )
 
 var localFlags pflag.FlagSet
@@ -67,6 +68,11 @@ func initGlobalFlags(globalFlags *pflag.FlagSet) {
 		// we instead rely on the default bash behavior
 		globalFlags.SetAnnotation("config", cobra.BashCompFilenameExt, []string{"yaml", "yml"})
 	}
+
+	// Add all global flags to the set of valid config properties.
+	globalFlags.VisitAll(func(flag *pflag.Flag) {
+		internal.AddValidProp(flag.Name)
+	})
 }
 
 func initLocalFlags() {
@@ -99,4 +105,9 @@ func initLocalFlags() {
 		localFlags.SetAnnotation("objects", cobra.BashCompFilenameExt, []string{"json"})
 		localFlags.SetAnnotation("script", cobra.BashCompFilenameExt, []string{"qvs"})
 	}
+
+	// Add all local flags to the set of valid config properties.
+	localFlags.VisitAll(func(flag *pflag.Flag) {
+		internal.AddValidProp(flag.Name)
+	})
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -2,13 +2,14 @@ package internal
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
-	leven "github.com/texttheater/golang-levenshtein/levenshtein"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/viper"
+	leven "github.com/texttheater/golang-levenshtein/levenshtein"
+	"gopkg.in/yaml.v2"
 )
 
 // ConnectionConfigEntry defines the content of a connection in either the project config yml file or a connections yml file.
@@ -29,6 +30,9 @@ type ConnectionsConfigFile struct {
 type FileWithReferenceToConfigFile struct {
 	Connections string
 }
+
+// validProps is the set of valid config properties.
+var validProps map[string]struct{} = map[string]struct{}{}
 
 func ResolveConnectionsFileReferenceInConfigFile(projectPath string) string {
 	var configFileWithFileReference FileWithReferenceToConfigFile
@@ -97,17 +101,16 @@ func ReadConfigFile(explicitConfigFile string) {
 	}
 }
 
+// AddValidProp adds the given property to the set of valid properties.
+func AddValidProp(propName string) {
+	validProps[propName] = struct{}{}
+}
+
 // validateProps reads a config file by
 func validateProps(configPath string) {
 	source, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		FatalError("Could not find config file:", configPath)
-	}
-	validProps := map[string]struct{}{ // This "set" contains the valid property names
-		"app": {}, "engine": {}, "measures": {}, "script": {},
-		"dimensions": {}, "objects": {}, "connections": {},
-		"headers": {}, "verbose": {}, "traffic": {},
-		"no-data": {}, "bash": {},
 	}
 	configProps := map[string]interface{}{}
 	err = yaml.Unmarshal(source, &configProps)


### PR DESCRIPTION
Valid properties are no longer hard coded.
They are instead added dynamically in the `cmd/flags.go` file.

I figured that `validProps` should be private since I can't see any reason this would be needed elsewhere.