### PR TITLE
Check if app exists before rm confirmation

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -34,9 +34,13 @@ var removeAppCmd = withLocalFlags(&cobra.Command{
 	Example: "corectl app rm APP-ID",
 
 	Run: func(ccmd *cobra.Command, args []string) {
-		app := viper.GetString("app")
-		app = args[0]
+		app := args[0]
 
+		exists := internal.AppExists(rootCtx, viper.GetString("engine"), app, viper.GetString("ttl"), headers)
+		if !exists {
+			errMsg := fmt.Sprintf("Error: Could not find any app by the name '%s'.", app)
+			internal.FatalError(errMsg)
+		}
 		confirmed := askForConfirmation(fmt.Sprintf("Do you really want to delete the app: %s?", app))
 
 		if confirmed {

--- a/internal/knownapps.go
+++ b/internal/knownapps.go
@@ -26,7 +26,7 @@ func applyNameToIDTransformation(engineURL string, appName string) (appID string
 		return id, true
 	}
 
-	LogVerbose("No id found for app with name: " + appName)
+	LogVerbose("No known id for app with name: " + appName)
 	return appName, false
 }
 

--- a/internal/state.go
+++ b/internal/state.go
@@ -68,6 +68,14 @@ func connectToEngine(ctx context.Context, engine string, appName string, ttl str
 	return global
 }
 
+//AppExists returns wether or not an app exists
+func AppExists(ctx context.Context, engine string, appName string, ttl string, headers http.Header) bool {
+	global := connectToEngine(ctx, engine, appName, ttl, headers)
+	appID, _ := applyNameToIDTransformation(engine, appName)
+	_, err := global.GetAppEntry(ctx, appID)
+	return err == nil
+}
+
 //DeleteApp removes the specified app from the engine.
 func DeleteApp(ctx context.Context, engine string, appName string, ttl string, headers http.Header) {
 	global := connectToEngine(ctx, engine, appName, ttl, headers)


### PR DESCRIPTION
This PR changes so that before attempting to delete an app it checks whether or not such an app exists.
Mainly so that the user does not have to confirm something that can't happen.
