### PR TITLE
Update license file with path to completion

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -20,4 +20,4 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-cmd/utils.go is based on https://github.com/kubernetes/kubernetes/blob/e2c1f435516085ef17f222fb7f89cd3ba13aa944/pkg/kubectl/cmd/completion/completion.go, licensed under the Apache License, Version 2.0.
+cmd/completion.go is based on https://github.com/kubernetes/kubernetes/blob/e2c1f435516085ef17f222fb7f89cd3ba13aa944/pkg/kubectl/cmd/completion/completion.go, licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
During the refactoring of the command structure the completion implementation was moved to a separate file. We also need to update the license file with the new path.