### PR TITLE
Json responses

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -22,7 +22,7 @@ var getAppsCmd = &cobra.Command{
 		if err != nil {
 			internal.FatalError(err)
 		}
-		printer.PrintApps(docList, !viper.GetBool("bash"), viper.GetBool("bash"))
+		printer.PrintApps(docList, viper.GetBool("bash"))
 	},
 }
 

--- a/cmd/connection.go
+++ b/cmd/connection.go
@@ -63,7 +63,7 @@ var listConnectionsCmd = &cobra.Command{
 		if err != nil {
 			internal.FatalError(err)
 		}
-		printer.PrintConnections(connections, !viper.GetBool("bash"), viper.GetBool("bash"))
+		printer.PrintConnections(connections, viper.GetBool("bash"))
 	},
 }
 

--- a/cmd/entity_util.go
+++ b/cmd/entity_util.go
@@ -36,5 +36,5 @@ func listEntities(ccmd *cobra.Command, args []string, entityType string, printAs
 	if err != nil {
 		internal.FatalError(err)
 	}
-	printer.PrintGenericEntities(allInfos, entityType, printAsJSON, viper.GetBool("bash"))
+	printer.PrintGenericEntities(allInfos, entityType, viper.GetBool("bash"))
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -47,7 +47,7 @@ func initGlobalFlags(globalFlags *pflag.FlagSet) {
 	globalFlags.StringP("engine", "e", "localhost:9076", "URL to the Qlik Associative Engine")
 	globalFlags.StringP("app", "a", "", "App name, if no app is specified a session app is used instead")
 	globalFlags.String("ttl", "30", "Qlik Associative Engine session time to live in seconds")
-	globalFlags.Bool("json", false, "Returns output in JSON format if possible, overrides the verbose and traffic flags")
+	globalFlags.Bool("json", false, "Returns output in JSON format if possible, disables verbose and traffic output")
 	globalFlags.Bool("no-data", false, "Open app without data")
 	globalFlags.Bool("bash", false, "Bash flag used to adapt output to bash completion format")
 	globalFlags.MarkHidden("bash")

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -47,6 +47,7 @@ func initGlobalFlags(globalFlags *pflag.FlagSet) {
 	globalFlags.StringP("engine", "e", "localhost:9076", "URL to the Qlik Associative Engine")
 	globalFlags.StringP("app", "a", "", "App name, if no app is specified a session app is used instead")
 	globalFlags.String("ttl", "30", "Qlik Associative Engine session time to live in seconds")
+	globalFlags.Bool("json", false, "Returns output in JSON format if possible, overrides the verbose and traffic flags")
 	globalFlags.Bool("no-data", false, "Open app without data")
 	globalFlags.Bool("bash", false, "Bash flag used to adapt output to bash completion format")
 	globalFlags.MarkHidden("bash")

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -18,7 +18,7 @@ corectl [flags]
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -18,6 +18,7 @@ corectl [flags]
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_app.md
+++ b/docs/corectl_app.md
@@ -19,6 +19,7 @@ Explore and manage apps
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_app.md
+++ b/docs/corectl_app.md
@@ -19,7 +19,7 @@ Explore and manage apps
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_app_ls.md
+++ b/docs/corectl_app_ls.md
@@ -29,7 +29,7 @@ corectl app ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_app_ls.md
+++ b/docs/corectl_app_ls.md
@@ -29,6 +29,7 @@ corectl app ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_app_rm.md
+++ b/docs/corectl_app_rm.md
@@ -30,6 +30,7 @@ corectl app rm APP-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_app_rm.md
+++ b/docs/corectl_app_rm.md
@@ -30,7 +30,7 @@ corectl app rm APP-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_assoc.md
+++ b/docs/corectl_assoc.md
@@ -30,7 +30,7 @@ corectl associations
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_assoc.md
+++ b/docs/corectl_assoc.md
@@ -30,6 +30,7 @@ corectl associations
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -38,6 +38,7 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -38,7 +38,7 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -31,7 +31,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -31,6 +31,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_completion.md
+++ b/docs/corectl_completion.md
@@ -37,7 +37,7 @@ corectl completion <shell> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_completion.md
+++ b/docs/corectl_completion.md
@@ -37,6 +37,7 @@ corectl completion <shell> [flags]
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection.md
+++ b/docs/corectl_connection.md
@@ -19,6 +19,7 @@ Explore and manage connections
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection.md
+++ b/docs/corectl_connection.md
@@ -19,7 +19,7 @@ Explore and manage connections
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection_get.md
+++ b/docs/corectl_connection_get.md
@@ -29,7 +29,7 @@ corectl connection get CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection_get.md
+++ b/docs/corectl_connection_get.md
@@ -29,6 +29,7 @@ corectl connection get CONNECTION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection_ls.md
+++ b/docs/corectl_connection_ls.md
@@ -29,7 +29,7 @@ corectl connection ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection_ls.md
+++ b/docs/corectl_connection_ls.md
@@ -29,6 +29,7 @@ corectl connection ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection_rm.md
+++ b/docs/corectl_connection_rm.md
@@ -31,7 +31,7 @@ corectl connection rm ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection_rm.md
+++ b/docs/corectl_connection_rm.md
@@ -31,6 +31,7 @@ corectl connection rm ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection_set.md
+++ b/docs/corectl_connection_set.md
@@ -29,7 +29,7 @@ corectl connection set ./my-connections.yml
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_connection_set.md
+++ b/docs/corectl_connection_set.md
@@ -29,6 +29,7 @@ corectl connection set ./my-connections.yml
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension.md
+++ b/docs/corectl_dimension.md
@@ -19,6 +19,7 @@ Explore and manage dimensions
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension.md
+++ b/docs/corectl_dimension.md
@@ -19,7 +19,7 @@ Explore and manage dimensions
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_layout.md
+++ b/docs/corectl_dimension_layout.md
@@ -29,7 +29,7 @@ corectl dimension layout DIMENSION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_layout.md
+++ b/docs/corectl_dimension_layout.md
@@ -29,6 +29,7 @@ corectl dimension layout DIMENSION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_ls.md
+++ b/docs/corectl_dimension_ls.md
@@ -29,6 +29,7 @@ corectl dimension ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_ls.md
+++ b/docs/corectl_dimension_ls.md
@@ -29,7 +29,7 @@ corectl dimension ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_properties.md
+++ b/docs/corectl_dimension_properties.md
@@ -29,7 +29,7 @@ corectl dimension properties DIMENSION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_properties.md
+++ b/docs/corectl_dimension_properties.md
@@ -29,6 +29,7 @@ corectl dimension properties DIMENSION-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_rm.md
+++ b/docs/corectl_dimension_rm.md
@@ -30,6 +30,7 @@ corectl dimension rm ID-1
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_rm.md
+++ b/docs/corectl_dimension_rm.md
@@ -30,7 +30,7 @@ corectl dimension rm ID-1
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_set.md
+++ b/docs/corectl_dimension_set.md
@@ -30,7 +30,7 @@ corectl dimension set ./my-dimensions-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_dimension_set.md
+++ b/docs/corectl_dimension_set.md
@@ -30,6 +30,7 @@ corectl dimension set ./my-dimensions-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -32,6 +32,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -32,7 +32,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_fields.md
+++ b/docs/corectl_fields.md
@@ -29,7 +29,7 @@ corectl fields
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_fields.md
+++ b/docs/corectl_fields.md
@@ -29,6 +29,7 @@ corectl fields
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_keys.md
+++ b/docs/corectl_keys.md
@@ -29,7 +29,7 @@ corectl keys
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_keys.md
+++ b/docs/corectl_keys.md
@@ -29,6 +29,7 @@ corectl keys
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure.md
+++ b/docs/corectl_measure.md
@@ -19,7 +19,7 @@ Explore and manage measures
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure.md
+++ b/docs/corectl_measure.md
@@ -19,6 +19,7 @@ Explore and manage measures
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_layout.md
+++ b/docs/corectl_measure_layout.md
@@ -29,7 +29,7 @@ corectl measure layout MEASURE-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_layout.md
+++ b/docs/corectl_measure_layout.md
@@ -29,6 +29,7 @@ corectl measure layout MEASURE-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_ls.md
+++ b/docs/corectl_measure_ls.md
@@ -29,6 +29,7 @@ corectl measure ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_ls.md
+++ b/docs/corectl_measure_ls.md
@@ -29,7 +29,7 @@ corectl measure ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_properties.md
+++ b/docs/corectl_measure_properties.md
@@ -29,6 +29,7 @@ corectl measure properties MEASURE-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_properties.md
+++ b/docs/corectl_measure_properties.md
@@ -29,7 +29,7 @@ corectl measure properties MEASURE-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_rm.md
+++ b/docs/corectl_measure_rm.md
@@ -30,7 +30,7 @@ corectl measure rm ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_rm.md
+++ b/docs/corectl_measure_rm.md
@@ -30,6 +30,7 @@ corectl measure rm ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_set.md
+++ b/docs/corectl_measure_set.md
@@ -30,6 +30,7 @@ corectl measure set ./my-measures-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_measure_set.md
+++ b/docs/corectl_measure_set.md
@@ -30,7 +30,7 @@ corectl measure set ./my-measures-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_meta.md
+++ b/docs/corectl_meta.md
@@ -30,7 +30,7 @@ corectl meta --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_meta.md
+++ b/docs/corectl_meta.md
@@ -30,6 +30,7 @@ corectl meta --app my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object.md
+++ b/docs/corectl_object.md
@@ -19,6 +19,7 @@ Explore and manage generic objects
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object.md
+++ b/docs/corectl_object.md
@@ -19,7 +19,7 @@ Explore and manage generic objects
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_data.md
+++ b/docs/corectl_object_data.md
@@ -29,6 +29,7 @@ corectl object data OBJECT-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_data.md
+++ b/docs/corectl_object_data.md
@@ -29,7 +29,7 @@ corectl object data OBJECT-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_layout.md
+++ b/docs/corectl_object_layout.md
@@ -29,6 +29,7 @@ corectl object layout OBJECT-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_layout.md
+++ b/docs/corectl_object_layout.md
@@ -29,7 +29,7 @@ corectl object layout OBJECT-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_ls.md
+++ b/docs/corectl_object_ls.md
@@ -29,7 +29,7 @@ corectl object ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_ls.md
+++ b/docs/corectl_object_ls.md
@@ -29,6 +29,7 @@ corectl object ls
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_properties.md
+++ b/docs/corectl_object_properties.md
@@ -29,6 +29,7 @@ corectl object properties OBJECT-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_properties.md
+++ b/docs/corectl_object_properties.md
@@ -29,7 +29,7 @@ corectl object properties OBJECT-ID
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_rm.md
+++ b/docs/corectl_object_rm.md
@@ -30,6 +30,7 @@ corectl object rm ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_rm.md
+++ b/docs/corectl_object_rm.md
@@ -30,7 +30,7 @@ corectl object rm ID-1 ID-2
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_set.md
+++ b/docs/corectl_object_set.md
@@ -31,6 +31,7 @@ corectl object set ./my-objects-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_object_set.md
+++ b/docs/corectl_object_set.md
@@ -31,7 +31,7 @@ corectl object set ./my-objects-glob-path.json
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -31,6 +31,7 @@ corectl reload
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -31,7 +31,7 @@ corectl reload
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_script.md
+++ b/docs/corectl_script.md
@@ -19,7 +19,7 @@ Explore and manage the script
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_script.md
+++ b/docs/corectl_script.md
@@ -19,6 +19,7 @@ Explore and manage the script
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_script_get.md
+++ b/docs/corectl_script_get.md
@@ -29,6 +29,7 @@ corectl script get
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_script_get.md
+++ b/docs/corectl_script_get.md
@@ -29,7 +29,7 @@ corectl script get
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_script_set.md
+++ b/docs/corectl_script_set.md
@@ -30,6 +30,7 @@ corectl script set ./my-script-file.qvs
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_script_set.md
+++ b/docs/corectl_script_set.md
@@ -30,7 +30,7 @@ corectl script set ./my-script-file.qvs
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_status.md
+++ b/docs/corectl_status.md
@@ -30,7 +30,7 @@ corectl status --app=my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_status.md
+++ b/docs/corectl_status.md
@@ -30,6 +30,7 @@ corectl status --app=my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_tables.md
+++ b/docs/corectl_tables.md
@@ -30,6 +30,7 @@ corectl tables --app=my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_tables.md
+++ b/docs/corectl_tables.md
@@ -30,7 +30,7 @@ corectl tables --app=my-app.qvf
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_values.md
+++ b/docs/corectl_values.md
@@ -29,7 +29,7 @@ corectl values FIELD
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_values.md
+++ b/docs/corectl_values.md
@@ -29,6 +29,7 @@ corectl values FIELD
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -29,6 +29,7 @@ corectl version
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -29,7 +29,7 @@ corectl version
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -31,7 +31,7 @@
       "default": "[]"
     },
     "json": {
-      "description": "Returns output in JSON format if possible, overrides the verbose and traffic flags",
+      "description": "Returns output in JSON format if possible, disables verbose and traffic output",
       "default": "false"
     },
     "no-data": {

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -30,6 +30,10 @@
       "description": "Http headers to use when connecting to Qlik Associative Engine",
       "default": "[]"
     },
+    "json": {
+      "description": "Returns output in JSON format if possible, overrides the verbose and traffic flags",
+      "default": "false"
+    },
     "no-data": {
       "description": "Open app without data",
       "default": "false"

--- a/internal/config.go
+++ b/internal/config.go
@@ -118,8 +118,7 @@ func ReadConfigFile(explicitConfigFile string) {
 			setConfigFile(configFile)
 		}
 	}
-	QliVerbose = viper.GetBool("verbose")
-	LogTraffic = viper.GetBool("traffic")
+	InitLogOutput() // sets json, verbose and traffic
 	if configFile != "" {
 		ConfigDir = filepath.Dir(configFile)
 		LogVerbose("Using config file: " + configFile)

--- a/internal/log.go
+++ b/internal/log.go
@@ -1,13 +1,30 @@
 package internal
 
-import "fmt"
+import (
+	"fmt"
 
-// QliVerbose is set to true to indicate that verbose logging should be enabled.
-var QliVerbose bool
+	"github.com/spf13/viper"
+)
+
+// PrintVerbose is set to true to indicate that verbose logging should be enabled.
+var PrintVerbose bool
+
+// PrintJSON represents whether all output should be in JSON format or not.
+var PrintJSON bool
+
+// InitLogOutput reads the viper flags json, verbose and traffic and sets the
+// internal loggin variables PrintJSON, PrintVerbose and LogTraffic accordingly.
+func InitLogOutput() {
+	PrintJSON = viper.GetBool("json")
+	if !PrintJSON {
+		PrintVerbose = viper.GetBool("verbose")
+		LogTraffic = viper.GetBool("traffic")
+	}
+}
 
 // LogVerbose prints the supplied message to system out if verbose logging is enabled.
 func LogVerbose(message string) {
-	if QliVerbose {
+	if PrintVerbose {
 		fmt.Println(message)
 	}
 }

--- a/internal/log.go
+++ b/internal/log.go
@@ -1,7 +1,10 @@
 package internal
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/viper"
 )
@@ -50,3 +53,27 @@ func (TrafficLogger) Received(message []byte) {
 
 // Closed implements Closed() method in enigma-go TrafficLogger interface
 func (TrafficLogger) Closed() {}
+
+// FatalError prints the supplied message and exists the process with code 1
+func FatalError(fatalMessage ...interface{}) {
+	if PrintJSON {
+		errMsg := map[string]string{
+			"error": fmt.Sprint(fatalMessage...),
+		}
+		PrintAsJSON(errMsg)
+	} else {
+		fmt.Println(fatalMessage...)
+	}
+	os.Exit(1)
+}
+
+// PrintAsJSON prints data as JSON
+func PrintAsJSON(data interface{}) {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		FatalError(err)
+	}
+	var buffer bytes.Buffer
+	json.Indent(&buffer, jsonBytes, "", "   ")
+	fmt.Println(buffer.String())
+}

--- a/internal/state.go
+++ b/internal/state.go
@@ -285,9 +285,3 @@ func getSessionID(appID string) string {
 	sessionID := base64.StdEncoding.EncodeToString([]byte("corectl-" + currentUser.Username + "-" + hostName + "-" + appID + "-" + ttl + "-" + strconv.FormatBool(noData)))
 	return sessionID
 }
-
-// FatalError prints the supplied message and exists the process with code 1
-func FatalError(fatalMessage ...interface{}) {
-	fmt.Println(fatalMessage...)
-	os.Exit(1)
-}

--- a/printer/apps.go
+++ b/printer/apps.go
@@ -1,7 +1,6 @@
 package printer
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -15,13 +14,9 @@ import (
 )
 
 // PrintApps prints a list of apps and some meta to system out.
-func PrintApps(docList []*enigma.DocListEntry, printAsJSON bool, printAsBash bool) {
-	if printAsJSON {
-		buffer, err := json.Marshal(filterDocEntries(docList))
-		if err != nil {
-			internal.FatalError(err)
-		}
-		fmt.Println(prettyJSON(buffer))
+func PrintApps(docList []*enigma.DocListEntry, printAsBash bool) {
+	if internal.PrintJSON {
+		internal.PrintAsJSON(filterDocEntries(docList))
 	} else if printAsBash {
 		for _, app := range docList {
 			PrintToBashComp(app.DocName)

--- a/printer/connections.go
+++ b/printer/connections.go
@@ -9,7 +9,7 @@ import (
 )
 
 // PrintConnections prints a list of connections to standard out
-func PrintConnections(connections []*enigma.Connection, printAsJSON bool, printAsBash bool) {
+func PrintConnections(connections []*enigma.Connection, printAsBash bool) {
 	if internal.PrintJSON {
 		internal.PrintAsJSON(connections)
 	} else if printAsBash {
@@ -30,7 +30,5 @@ func PrintConnections(connections []*enigma.Connection, printAsJSON bool, printA
 
 // PrintConnection prints a connection to standard out
 func PrintConnection(connection *enigma.Connection) {
-	if internal.PrintJSON {
-		internal.PrintAsJSON(connection)
-	}
+	internal.PrintAsJSON(connection)
 }

--- a/printer/connections.go
+++ b/printer/connections.go
@@ -1,8 +1,6 @@
 package printer
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/olekukonko/tablewriter"
@@ -12,8 +10,8 @@ import (
 
 // PrintConnections prints a list of connections to standard out
 func PrintConnections(connections []*enigma.Connection, printAsJSON bool, printAsBash bool) {
-	if printAsJSON {
-		jsonPrinter(connections)
+	if internal.PrintJSON {
+		internal.PrintAsJSON(connections)
 	} else if printAsBash {
 		for _, connection := range connections {
 			PrintToBashComp(connection.Id)
@@ -32,13 +30,7 @@ func PrintConnections(connections []*enigma.Connection, printAsJSON bool, printA
 
 // PrintConnection prints a connection to standard out
 func PrintConnection(connection *enigma.Connection) {
-	jsonPrinter(connection)
-}
-
-func jsonPrinter(v interface{}) {
-	buffer, err := json.Marshal(v)
-	if err != nil {
-		internal.FatalError(err)
+	if internal.PrintJSON {
+		internal.PrintAsJSON(connection)
 	}
-	fmt.Println(prettyJSON(buffer))
 }

--- a/printer/entities.go
+++ b/printer/entities.go
@@ -1,7 +1,6 @@
 package printer
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -14,19 +13,15 @@ import (
 )
 
 // PrintGenericEntities prints a list of the id and type of all generic entities in the app
-func PrintGenericEntities(allInfos []*enigma.NxInfo, entityType string, printAsJSON bool, printAsBash bool) {
-	if printAsJSON {
+func PrintGenericEntities(allInfos []*enigma.NxInfo, entityType string, printAsBash bool) {
+	if internal.PrintJSON {
 		specifiedEntityTypeInfos := []*enigma.NxInfo{}
 		for _, info := range allInfos {
 			if (entityType == "object" && info.Type != "measure" && info.Type != "dimension") || entityType == info.Type {
 				specifiedEntityTypeInfos = append(specifiedEntityTypeInfos, info)
 			}
 		}
-		buffer, err := json.Marshal(specifiedEntityTypeInfos)
-		if err != nil {
-			internal.FatalError(err)
-		}
-		fmt.Println(prettyJSON(buffer))
+		internal.PrintAsJSON(specifiedEntityTypeInfos)
 	} else if printAsBash {
 		for _, info := range allInfos {
 			if (entityType == "object" && info.Type != "measure" && info.Type != "dimension") || entityType == info.Type {
@@ -74,11 +69,10 @@ func PrintGenericEntityProperties(state *internal.State, entityID string, entity
 	if err != nil {
 		internal.FatalError(err)
 	}
-	json := prettyJSON(properties)
-	if len(json) == 0 {
-		fmt.Printf("Error: No %s by id '%s'\n", entityType, entityID)
+	if len(properties) == 0 {
+		internal.FatalError(fmt.Sprintf("No %s by id '%s'", entityType, entityID))
 	} else {
-		fmt.Println(json)
+		internal.PrintAsJSON(properties)
 	}
 }
 
@@ -109,18 +103,11 @@ func PrintGenericEntityLayout(state *internal.State, entityID string, entityType
 	if err != nil {
 		internal.FatalError(err)
 	}
-	json := prettyJSON(layout)
-	if len(json) == 0 {
-		fmt.Printf("Error: No %s by id '%s'\n", entityType, entityID)
+	if len(layout) == 0 {
+		internal.FatalError(fmt.Sprintf("No %s by id '%s'", entityType, entityID))
 	} else {
-		fmt.Println(json)
+		internal.PrintAsJSON(layout)
 	}
-}
-
-func prettyJSON(data []byte) string {
-	var prettyJSON bytes.Buffer
-	json.Indent(&prettyJSON, data, "", "   ")
-	return prettyJSON.String()
 }
 
 // EvalObject evalutes the data of the object identified by objectID

--- a/printer/entities.go
+++ b/printer/entities.go
@@ -130,8 +130,7 @@ func EvalObject(ctx context.Context, doc *enigma.Doc, objectID string) {
 	resultCubeMap := make(map[string]*enigma.HyperCube)
 	getAllHyperCubes("", layoutMap, resultCubeMap)
 	if len(resultCubeMap) == 0 {
-		fmt.Printf("Object %s contains no data\n", objectID)
-		return
+		internal.FatalError(fmt.Sprintf("Object %s contains no data\n", objectID))
 	}
 	for _, hypercube := range resultCubeMap {
 		printHypercube(hypercube)

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package test
 
 import (

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package test
 
 import (
@@ -87,7 +85,7 @@ func setupEntities(connectToEngine string, configPath string, entityType string,
 	cmd := exec.Command(binaryPath, []string{connectToEngine, configPath, "build", entityPath}...)
 	fmt.Println(cmd)
 	cmd.Run()
-	cmd = exec.Command(binaryPath, []string{connectToEngine, configPath, entityType, "ls"}...)
+	cmd = exec.Command(binaryPath, []string{connectToEngine, configPath, entityType, "ls", "--json"}...)
 	fmt.Println(cmd)
 	output, _ := cmd.CombinedOutput()
 	return output
@@ -100,7 +98,7 @@ func removeEntities(t *testing.T, connectToEngine string, configPath string, ent
 }
 
 func verifyNoEntities(t *testing.T, connectToEngine string, configPath string, entityType string) {
-	cmd := exec.Command(binaryPath, []string{connectToEngine, configPath, entityType, "ls"}...)
+	cmd := exec.Command(binaryPath, []string{connectToEngine, configPath, entityType, "ls", "--json"}...)
 	output, _ := cmd.CombinedOutput()
 	assert.Equal(t, "[]\n", string(output))
 }
@@ -226,18 +224,18 @@ func TestCorectl(t *testing.T) {
 		{"project 1 - eval", defaultConnectString1, []string{"eval", "=1+1"}, []string{"golden", "project1-eval-3.golden"}, initTest{true, true}},
 		{"project 1 - eval", defaultConnectString1, []string{"eval", "1+1"}, []string{"golden", "project1-eval-4.golden"}, initTest{true, true}},
 		{"project 1 - eval", defaultConnectString1, []string{"eval", "by", "numbers"}, []string{"golden", "project1-eval-5.golden"}, initTest{true, true}},
-		{"project 1 - get objects", defaultConnectString1, []string{"object", "ls"}, []string{"golden", "project1-objects.golden"}, initTest{true, true}},
+		{"project 1 - get objects", defaultConnectString1, []string{"object", "ls", "--json"}, []string{"golden", "project1-objects.golden"}, initTest{true, true}},
 		{"project 1 - get object data", defaultConnectString1, []string{"object", "data", "my-hypercube"}, []string{"golden", "project1-data.golden"}, initTest{true, true}},
-		{"project 1 - get object properties", defaultConnectString1, []string{"object", "properties", "my-hypercube"}, []string{"golden", "project1-properties.golden"}, initTest{true, true}},
-		{"project 1 - get measures 1 as json", defaultConnectString1, []string{"measure", "ls"}, []string{"golden", "project1-measures-1-json.golden"}, initTest{true, true}},
-		{"project 1 - get dimensions", defaultConnectString1, []string{"dimension", "ls"}, []string{"golden", "project1-dimensions.golden"}, initTest{true, true}},
+		{"project 1 - get object properties", defaultConnectString1, []string{"object", "properties", "my-hypercube", "--json"}, []string{"golden", "project1-properties.golden"}, initTest{true, true}},
+		{"project 1 - get measures 1 as json", defaultConnectString1, []string{"measure", "ls", "--json"}, []string{"golden", "project1-measures-1-json.golden"}, initTest{true, true}},
+		{"project 1 - get dimensions", defaultConnectString1, []string{"dimension", "ls", "--json"}, []string{"golden", "project1-dimensions.golden"}, initTest{true, true}},
 		{"project 1 - get script", defaultConnectString1, []string{"script", "get"}, []string{"golden", "project1-script.golden"}, initTest{true, true}},
 		{"project 1 - reload without progress", defaultConnectString1, []string{"reload", "--silent"}, []string{"golden", "project1-reload-silent.golden"}, initTest{true, true}},
 		{"project 1 - reload without progress and without save", defaultConnectString1, []string{"reload", "--silent", "--no-save"}, []string{"golden", "project1-reload-silent-no-save.golden"}, initTest{true, true}},
 		{"project 1 - set measures", defaultConnectString1, []string{"measure", "set", "test/project1/not-following-glob-pattern-measure.json", "--no-save"}, []string{"golden", "blank.golden"}, initTest{true, true}},
-		{"project 1 - get measures 2", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"measure", "ls"}, []string{"golden", "project1-measures-2.golden"}, initTest{true, true}},
+		{"project 1 - get measures 2", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"measure", "ls", "--json"}, []string{"golden", "project1-measures-2.golden"}, initTest{true, true}},
 		{"project 1 - remove measures", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"measure", "rm", "measure-3", "--no-save"}, []string{"golden", "blank.golden"}, initTest{true, true}},
-		{"project 1 - check measures after removal", defaultConnectString1, []string{"measure", "ls"}, []string{"golden", "project1-measures-1.golden"}, initTest{true, true}},
+		{"project 1 - check measures after removal", defaultConnectString1, []string{"measure", "ls", "--json"}, []string{"golden", "project1-measures-1.golden"}, initTest{true, true}},
 		{"project 1 - set script", defaultConnectString1, []string{"script", "set", "test/project1/dummy-script.qvs", "--no-save"}, []string{"golden", "blank.golden"}, initTest{true, true}},
 		{"project 1 - get script after setting it", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"script", "set", "test/project1/dummy-script.qvs"}, []string{"golden", "project1-script-2.golden"}, initTest{true, true}},
 		{"project 1 - traffic logging", []string{"--config=test/project1/corectl-alt.yml", connectToEngine}, []string{"script", "set", "test/project1/dummy-script.qvs", "--traffic"}, []string{"golden", "project1-traffic-log.golden"}, initTest{true, true}},
@@ -260,7 +258,7 @@ func TestCorectl(t *testing.T) {
 		{"err 3", []string{connectToEngine, "--app=" + testAppName, "--headers=authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0"}, []string{"object", "data", "nosuchobject"}, []string{"golden", "err-3.golden"}, initTest{true, true}},
 
 		{"project 1 - get status", defaultConnectString1, []string{"status"}, []string{"Connected to " + testAppName + " @ ", "The data model has 2 tables."}, initTest{true, true}},
-		{"list apps json", defaultConnectString1, []string{"app", "ls"}, []string{"\"id\": \"/apps/" + testAppName + "\","}, initTest{true, true}},
+		{"list apps json", defaultConnectString1, []string{"app", "ls", "--json"}, []string{"\"id\": \"/apps/" + testAppName + "\","}, initTest{true, true}},
 		{"err 1", []string{"--engine=localhost:9999"}, []string{"fields"}, []string{"Please check the --engine parameter or your config file", "Error details:  dial tcp"}, initTest{false, false}},
 
 		// trying to connect to an engine that has JWT authorization activated without a JWT Header
@@ -269,7 +267,7 @@ func TestCorectl(t *testing.T) {
 
 		// Verifying corectl against an engine running with ABAC enabled
 		{"project 4 - get status", []string{"--config=test/project4/corectl.yml ", connectToEngineABAC}, []string{"status"}, []string{"Connected to " + testAppName + " @ ", "The data model has 1 table."}, initTest{true, true}},
-		{"project 4 - list apps", []string{"--config=test/project4/corectl.yml ", connectToEngineABAC}, []string{"app", "ls"}, []string{"\"title\": \"" + testAppName + "\","}, initTest{true, true}},
+		{"project 4 - list apps", []string{"--config=test/project4/corectl.yml ", connectToEngineABAC}, []string{"app", "ls", "--json"}, []string{"\"title\": \"" + testAppName + "\","}, initTest{true, true}},
 		{"project 4 - get meta", []string{"--config=test/project4/corectl.yml ", connectToEngineABAC}, []string{"meta"}, []string{"golden", "project4-meta.golden"}, initTest{true, true}},
 
 		// Verifying config validation

--- a/test/golden/help-1.golden
+++ b/test/golden/help-1.golden
@@ -38,7 +38,7 @@ Flags:
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/test/golden/help-1.golden
+++ b/test/golden/help-1.golden
@@ -38,6 +38,7 @@ Flags:
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/test/golden/help-2.golden
+++ b/test/golden/help-2.golden
@@ -38,7 +38,7 @@ Flags:
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/test/golden/help-2.golden
+++ b/test/golden/help-2.golden
@@ -38,6 +38,7 @@ Flags:
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/test/golden/help-3.golden
+++ b/test/golden/help-3.golden
@@ -23,6 +23,7 @@ Global Flags:
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
+      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")

--- a/test/golden/help-3.golden
+++ b/test/golden/help-3.golden
@@ -23,7 +23,7 @@ Global Flags:
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
-      --json                     Returns output in JSON format if possible, overrides the verbose and traffic flags
+      --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "30")


### PR DESCRIPTION
This PR adds a json flag at root level. This flag will override the verbose and traffic flag since so that any non-json output is suppressed.

Some restructuring regarding where the printing and logging functions are located is also part of this PR.


This ensures that json-responses contain only json and thus closes #225 