### PR TITLE
Validate api specification towards schema in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,25 @@ jobs:
             # Execute tests
             docker exec $TEST_CONTAINER /bin/bash -c 'cd /corectl && go test ./test/corectl_integration_test.go --engineIP $TEST_HOST:9076 --engine2IP $TEST_HOST:9176 --engine3IP $TEST_HOST:9276'
 
+  validate:
+    working_directory: ~/corectl
+    docker:
+      - image: circleci/node:8.15.1
+    steps:
+      - checkout
+      - run:
+          name: Install aws-cli
+          command: sudo apt-get update && sudo apt-get install -y awscli
+      - run:
+          name: Download api schema
+          command: aws s3 cp s3://${S3BUCKET}/schema.json ./docs/schema.json --region ${S3BUCKET_REGION}
+      - run:
+          name: Install ajv-cli
+          command: npm install -g ajv-cli
+      - run:
+          name: Validate api spec towards schema
+          command: ajv -s ./docs/schema.json -d ./docs/spec.json --json-pointers=true --all-errors=true
+
   publish:
     working_directory: ~/corectl
     docker:
@@ -77,9 +96,15 @@ workflows:
             tags:
               only:
                 - /v.*/
+      - validate:
+          filters:
+            tags:
+              only:
+                - /v.*/
       - publish:
           requires:
             - build
+            - validate
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           command: aws s3 cp s3://${S3BUCKET}/schema.json ./docs/schema.json --region ${S3BUCKET_REGION}
       - run:
           name: Install ajv-cli
-          command: npm install -g ajv-cli
+          command: sudo npm install -g ajv-cli
       - run:
           name: Validate api spec towards schema
           command: ajv -s ./docs/schema.json -d ./docs/spec.json --json-pointers=true --all-errors=true


### PR DESCRIPTION
This PR adds a Circle CI step for validating the api specification towards the schema using `ajv`.

This closes #240 