### PR TITLE
Handle websocket urls including paths and app identifiers

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -36,7 +36,7 @@ var removeAppCmd = withLocalFlags(&cobra.Command{
 	Run: func(ccmd *cobra.Command, args []string) {
 		app := args[0]
 
-		exists := internal.AppExists(rootCtx, viper.GetString("engine"), app, viper.GetString("ttl"), headers)
+		exists := internal.AppExists(rootCtx, viper.GetString("engine"), app, headers)
 		if !exists {
 			errMsg := fmt.Sprintf("Error: Could not find any app by the name '%s'.", app)
 			internal.FatalError(errMsg)
@@ -44,7 +44,7 @@ var removeAppCmd = withLocalFlags(&cobra.Command{
 		confirmed := askForConfirmation(fmt.Sprintf("Do you really want to delete the app: %s?", app))
 
 		if confirmed {
-			internal.DeleteApp(rootCtx, viper.GetString("engine"), app, viper.GetString("ttl"), headers)
+			internal.DeleteApp(rootCtx, viper.GetString("engine"), app, headers)
 		}
 	},
 }, "suppress")

--- a/internal/state.go
+++ b/internal/state.go
@@ -279,7 +279,9 @@ func tryParseAppFromURL(engineURL string) string {
 	re, _ := regexp.Compile("/app/([^/]+)")
 	values := re.FindStringSubmatch(u.Path)
 	if len(values) > 0 {
-		return values[1]
+		appName := values[1]
+		LogVerbose("Found app in engine url: " + appName)
+		return appName
 	}
 	return ""
 }

--- a/internal/state.go
+++ b/internal/state.go
@@ -276,7 +276,7 @@ func getSessionID(appID string) string {
 func parseAppFromURL(engineURL string) string {
 	u, _ := neturl.Parse(engineURL)
 	// Find any string in the path succeeding "/app/", and excluding anything after "/"
-	re, _ := regexp.Compile("/app/([^,/]+)")
+	re, _ := regexp.Compile("/app/([^/]+)")
 	values := re.FindStringSubmatch(u.Path)
 	if len(values) > 0 {
 		return values[1]

--- a/internal/state.go
+++ b/internal/state.go
@@ -10,6 +10,7 @@ import (
 	neturl "net/url"
 	"os"
 	"os/user"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -69,16 +70,16 @@ func connectToEngine(ctx context.Context, engine string, appName string, ttl str
 }
 
 //AppExists returns wether or not an app exists
-func AppExists(ctx context.Context, engine string, appName string, ttl string, headers http.Header) bool {
-	global := connectToEngine(ctx, engine, appName, ttl, headers)
+func AppExists(ctx context.Context, engine string, appName string, headers http.Header) bool {
+	global := PrepareEngineStateWithoutApp(ctx, headers).Global
 	appID, _ := applyNameToIDTransformation(engine, appName)
 	_, err := global.GetAppEntry(ctx, appID)
 	return err == nil
 }
 
 //DeleteApp removes the specified app from the engine.
-func DeleteApp(ctx context.Context, engine string, appName string, ttl string, headers http.Header) {
-	global := connectToEngine(ctx, engine, appName, ttl, headers)
+func DeleteApp(ctx context.Context, engine string, appName string, headers http.Header) {
+	global := PrepareEngineStateWithoutApp(ctx, headers).Global
 	appID, _ := applyNameToIDTransformation(engine, appName)
 	succ, err := global.DeleteApp(ctx, appID)
 	if err != nil {
@@ -98,7 +99,11 @@ func PrepareEngineState(ctx context.Context, headers http.Header, createAppIfMis
 	noData := viper.GetBool("no-data")
 
 	if appName == "" {
-		FatalError("Error: No app specified")
+		// No app name provided, lets check if one exists in the url
+		appName = parseAppFromURL(engine)
+		if appName == "" {
+			FatalError("Error: No app specified")
+		}
 	}
 
 	appID, _ := applyNameToIDTransformation(engine, appName)
@@ -226,23 +231,20 @@ func PrepareEngineStateWithoutApp(ctx context.Context, headers http.Header) *Sta
 
 //TidyUpEngineURL tidies up an engine url fragment and returns a complete url.
 func TidyUpEngineURL(engine string) string {
-	var url string
-	if strings.HasPrefix(engine, "wss://") {
-		url = engine
-	} else if strings.HasPrefix(engine, "ws://") {
-		url = engine
-	} else {
-		url = "ws://" + engine
+	if strings.HasPrefix(engine, "wss://") || strings.HasPrefix(engine, "ws://") {
+		return engine
 	}
-	if len(strings.Split(url, ":")) == 2 {
-		url += ":9076"
-	}
-	return url
+	return "ws://" + engine
 }
 
 func buildWebSocketURL(engine string, ttl string) string {
 	engine = TidyUpEngineURL(engine)
-	return engine + "/app/engineData/ttl/" + ttl
+	u, _ := neturl.Parse(engine)
+	// Only modify the url if it does not contain a path or ends with a "/"
+	if u.Path == "" && engine[len(engine)-1:] != "/" {
+		engine = engine + "/app/engineData/ttl/" + ttl
+	}
+	return engine
 }
 
 func buildMetadataURL(engine string, appID string) string {
@@ -268,4 +270,16 @@ func getSessionID(appID string) string {
 	}
 	sessionID := base64.StdEncoding.EncodeToString([]byte("corectl-" + currentUser.Username + "-" + hostName + "-" + appID + "-" + ttl + "-" + strconv.FormatBool(noData)))
 	return sessionID
+}
+
+// Function for parsing an url for an app identifier
+func parseAppFromURL(engineURL string) string {
+	u, _ := neturl.Parse(engineURL)
+	// Find any string in the path succeeding "/app/", and excluding anything after "/"
+	re, _ := regexp.Compile("/app/([^,/]+)")
+	values := re.FindStringSubmatch(u.Path)
+	if len(values) > 0 {
+		return values[1]
+	}
+	return ""
 }

--- a/internal/state.go
+++ b/internal/state.go
@@ -100,7 +100,7 @@ func PrepareEngineState(ctx context.Context, headers http.Header, createAppIfMis
 
 	if appName == "" {
 		// No app name provided, lets check if one exists in the url
-		appName = parseAppFromURL(engine)
+		appName = tryParseAppFromURL(engine)
 		if appName == "" {
 			FatalError("Error: No app specified")
 		}
@@ -273,7 +273,7 @@ func getSessionID(appID string) string {
 }
 
 // Function for parsing an url for an app identifier
-func parseAppFromURL(engineURL string) string {
+func tryParseAppFromURL(engineURL string) string {
 	u, _ := neturl.Parse(engineURL)
 	// Find any string in the path succeeding "/app/", and excluding anything after "/"
 	re, _ := regexp.Compile("/app/([^/]+)")

--- a/internal/state.go
+++ b/internal/state.go
@@ -242,7 +242,7 @@ func buildWebSocketURL(engine string, ttl string) string {
 	u, _ := neturl.Parse(engine)
 	// Only modify the url if it does not contain a path or ends with a "/"
 	if u.Path == "" && engine[len(engine)-1:] != "/" {
-		engine = engine + "/app/engineData/ttl/" + ttl
+		engine = engine + "/app/corectl/ttl/" + ttl
 	}
 	return engine
 }

--- a/internal/state.go
+++ b/internal/state.go
@@ -274,10 +274,9 @@ func getSessionID(appID string) string {
 
 // Function for parsing an url for an app identifier
 func tryParseAppFromURL(engineURL string) string {
-	u, _ := neturl.Parse(engineURL)
 	// Find any string in the path succeeding "/app/", and excluding anything after "/"
 	re, _ := regexp.Compile("/app/([^/]+)")
-	values := re.FindStringSubmatch(u.Path)
+	values := re.FindStringSubmatch(engineURL)
 	if len(values) > 0 {
 		appName := values[1]
 		LogVerbose("Found app in engine url: " + appName)

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -27,12 +27,14 @@ func TestBuildEngineUrl(t *testing.T) {
 }
 
 func TestParseAppFromUrl(t *testing.T) {
-	assert.Equal(t, parseAppFromURL("ws://engine/sense/app/test.qvf"), "test.qvf")
-	assert.Equal(t, parseAppFromURL("ws://engine/sense/app/test.qvf/"), "test.qvf")
-	assert.Equal(t, parseAppFromURL("ws://engine/sense/app/test.qvf/ttl/30"), "test.qvf")
-	assert.Equal(t, parseAppFromURL("ws://engine/sense/vp/app/test.qvf"), "test.qvf")
-	assert.Equal(t, parseAppFromURL("ws://engine/sense/vp/app/test.qvf/"), "test.qvf")
-	assert.Equal(t, parseAppFromURL("ws://engine/"), "")
-	assert.Equal(t, parseAppFromURL("ws://engine"), "")
-	assert.Equal(t, parseAppFromURL("ws://engine/sense"), "")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/app/test.qvf"), "test.qvf")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/app/test.qvf/"), "test.qvf")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/app/test.qvf/ttl/30"), "test.qvf")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/test.qvf"), "test.qvf")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/test.qvf/"), "test.qvf")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf/ttl/30"), "d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf/ttl/30"), "d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/"), "")
+	assert.Equal(t, tryParseAppFromURL("ws://engine"), "")
+	assert.Equal(t, tryParseAppFromURL("ws://engine/sense"), "")
 }

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -7,19 +7,32 @@ import (
 )
 
 func TestBuildMetaUrl(t *testing.T) {
-	assert.Equal(t, buildMetadataURL("engine", "appId"), "http://engine:9076/v1/apps/appId/data/metadata")
+	assert.Equal(t, buildMetadataURL("engine", "appId"), "http://engine/v1/apps/appId/data/metadata")
 	assert.Equal(t, buildMetadataURL("engine:1234", "appId"), "http://engine:1234/v1/apps/appId/data/metadata")
-	assert.Equal(t, buildMetadataURL("wss://engine", "appId"), "https://engine:9076/v1/apps/appId/data/metadata")
-	assert.Equal(t, buildMetadataURL("ws://engine", "appId"), "http://engine:9076/v1/apps/appId/data/metadata")
+	assert.Equal(t, buildMetadataURL("wss://engine", "appId"), "https://engine/v1/apps/appId/data/metadata")
+	assert.Equal(t, buildMetadataURL("ws://engine", "appId"), "http://engine/v1/apps/appId/data/metadata")
 	assert.Equal(t, buildMetadataURL("wss://engine:1234", "appId"), "https://engine:1234/v1/apps/appId/data/metadata")
 	assert.Equal(t, buildMetadataURL("ws://engine:1234", "appId"), "http://engine:1234/v1/apps/appId/data/metadata")
 }
 
 func TestBuildEngineUrl(t *testing.T) {
-	assert.Equal(t, buildWebSocketURL("engine", "30"), "ws://engine:9076/app/engineData/ttl/30")
+	assert.Equal(t, buildWebSocketURL("engine", "30"), "ws://engine/app/engineData/ttl/30")
 	assert.Equal(t, buildWebSocketURL("engine:1234", "30"), "ws://engine:1234/app/engineData/ttl/30")
-	assert.Equal(t, buildWebSocketURL("wss://engine", "30"), "wss://engine:9076/app/engineData/ttl/30")
-	assert.Equal(t, buildWebSocketURL("ws://engine", "30"), "ws://engine:9076/app/engineData/ttl/30")
+	assert.Equal(t, buildWebSocketURL("wss://engine", "30"), "wss://engine/app/engineData/ttl/30")
+	assert.Equal(t, buildWebSocketURL("ws://engine", "30"), "ws://engine/app/engineData/ttl/30")
 	assert.Equal(t, buildWebSocketURL("wss://engine:1234", "30"), "wss://engine:1234/app/engineData/ttl/30")
 	assert.Equal(t, buildWebSocketURL("ws://engine:1234", "30"), "ws://engine:1234/app/engineData/ttl/30")
+	assert.Equal(t, buildWebSocketURL("ws://engine:1234/sense/app/test.qvf", "30"), "ws://engine:1234/sense/app/test.qvf")
+	assert.Equal(t, buildWebSocketURL("ws://engine:1234/", "30"), "ws://engine:1234/")
+}
+
+func TestParseAppFromUrl(t *testing.T) {
+	assert.Equal(t, parseAppFromURL("ws://engine/sense/app/test.qvf"), "test.qvf")
+	assert.Equal(t, parseAppFromURL("ws://engine/sense/app/test.qvf/"), "test.qvf")
+	assert.Equal(t, parseAppFromURL("ws://engine/sense/app/test.qvf/ttl/30"), "test.qvf")
+	assert.Equal(t, parseAppFromURL("ws://engine/sense/vp/app/test.qvf"), "test.qvf")
+	assert.Equal(t, parseAppFromURL("ws://engine/sense/vp/app/test.qvf/"), "test.qvf")
+	assert.Equal(t, parseAppFromURL("ws://engine/"), "")
+	assert.Equal(t, parseAppFromURL("ws://engine"), "")
+	assert.Equal(t, parseAppFromURL("ws://engine/sense"), "")
 }

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -23,6 +23,7 @@ func TestBuildEngineUrl(t *testing.T) {
 	assert.Equal(t, buildWebSocketURL("wss://engine:1234", "30"), "wss://engine:1234/app/engineData/ttl/30")
 	assert.Equal(t, buildWebSocketURL("ws://engine:1234", "30"), "ws://engine:1234/app/engineData/ttl/30")
 	assert.Equal(t, buildWebSocketURL("ws://engine:1234/sense/app/test.qvf", "30"), "ws://engine:1234/sense/app/test.qvf")
+	assert.Equal(t, buildWebSocketURL("engine:1234/sense/app/test.qvf", "30"), "ws://engine:1234/sense/app/test.qvf")
 	assert.Equal(t, buildWebSocketURL("ws://engine:1234/", "30"), "ws://engine:1234/")
 }
 
@@ -32,6 +33,7 @@ func TestParseAppFromUrl(t *testing.T) {
 	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/app/test.qvf/ttl/30"), "test.qvf")
 	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/test.qvf"), "test.qvf")
 	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/test.qvf/"), "test.qvf")
+	assert.Equal(t, tryParseAppFromURL("engine/sense/vp/app/test.qvf/"), "test.qvf")
 	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf/ttl/30"), "d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf")
 	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf/ttl/30"), "d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf")
 	assert.Equal(t, tryParseAppFromURL("ws://engine/"), "")

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -16,12 +16,12 @@ func TestBuildMetaUrl(t *testing.T) {
 }
 
 func TestBuildEngineUrl(t *testing.T) {
-	assert.Equal(t, buildWebSocketURL("engine", "30"), "ws://engine/app/engineData/ttl/30")
-	assert.Equal(t, buildWebSocketURL("engine:1234", "30"), "ws://engine:1234/app/engineData/ttl/30")
-	assert.Equal(t, buildWebSocketURL("wss://engine", "30"), "wss://engine/app/engineData/ttl/30")
-	assert.Equal(t, buildWebSocketURL("ws://engine", "30"), "ws://engine/app/engineData/ttl/30")
-	assert.Equal(t, buildWebSocketURL("wss://engine:1234", "30"), "wss://engine:1234/app/engineData/ttl/30")
-	assert.Equal(t, buildWebSocketURL("ws://engine:1234", "30"), "ws://engine:1234/app/engineData/ttl/30")
+	assert.Equal(t, buildWebSocketURL("engine", "30"), "ws://engine/app/corectl/ttl/30")
+	assert.Equal(t, buildWebSocketURL("engine:1234", "30"), "ws://engine:1234/app/corectl/ttl/30")
+	assert.Equal(t, buildWebSocketURL("wss://engine", "30"), "wss://engine/app/corectl/ttl/30")
+	assert.Equal(t, buildWebSocketURL("ws://engine", "30"), "ws://engine/app/corectl/ttl/30")
+	assert.Equal(t, buildWebSocketURL("wss://engine:1234", "30"), "wss://engine:1234/app/corectl/ttl/30")
+	assert.Equal(t, buildWebSocketURL("ws://engine:1234", "30"), "ws://engine:1234/app/corectl/ttl/30")
 	assert.Equal(t, buildWebSocketURL("ws://engine:1234/sense/app/test.qvf", "30"), "ws://engine:1234/sense/app/test.qvf")
 	assert.Equal(t, buildWebSocketURL("engine:1234/sense/app/test.qvf", "30"), "ws://engine:1234/sense/app/test.qvf")
 	assert.Equal(t, buildWebSocketURL("ws://engine:1234/", "30"), "ws://engine:1234/")


### PR DESCRIPTION
Earlier `corectl` always appended `/app/engineData/ttl/<ttl>` to an engine url which led to incorrect behaviour when e.g. connecting to Qlik Sense Enterprise. Changed so that we only modify the url if it does not contain a path. Also if no app name is provided `corectl` will check if one is present in the url.

This closes #193 