### PR TITLE
Change default ttl value to zero

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -46,7 +46,7 @@ func initGlobalFlags(globalFlags *pflag.FlagSet) {
 	globalFlags.BoolP("traffic", "t", false, "Log JSON websocket traffic to stdout")
 	globalFlags.StringP("engine", "e", "localhost:9076", "URL to the Qlik Associative Engine")
 	globalFlags.StringP("app", "a", "", "Name or identifier of the app")
-	globalFlags.String("ttl", "30", "Qlik Associative Engine session time to live in seconds")
+	globalFlags.String("ttl", "0", "Qlik Associative Engine session time to live in seconds")
 	globalFlags.Bool("json", false, "Returns output in JSON format if possible, disables verbose and traffic output")
 	globalFlags.Bool("no-data", false, "Open app without data")
 	globalFlags.Bool("bash", false, "Bash flag used to adapt output to bash completion format")

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -21,7 +21,7 @@ corectl [flags]
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_app.md
+++ b/docs/corectl_app.md
@@ -22,7 +22,7 @@ Explore and manage apps
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_app_ls.md
+++ b/docs/corectl_app_ls.md
@@ -32,7 +32,7 @@ corectl app ls
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_app_rm.md
+++ b/docs/corectl_app_rm.md
@@ -33,7 +33,7 @@ corectl app rm APP-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_assoc.md
+++ b/docs/corectl_assoc.md
@@ -33,7 +33,7 @@ corectl associations
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -41,7 +41,7 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -34,7 +34,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_completion.md
+++ b/docs/corectl_completion.md
@@ -40,7 +40,7 @@ corectl completion <shell> [flags]
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_connection.md
+++ b/docs/corectl_connection.md
@@ -22,7 +22,7 @@ Explore and manage connections
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_connection_get.md
+++ b/docs/corectl_connection_get.md
@@ -32,7 +32,7 @@ corectl connection get CONNECTION-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_connection_ls.md
+++ b/docs/corectl_connection_ls.md
@@ -32,7 +32,7 @@ corectl connection ls
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_connection_rm.md
+++ b/docs/corectl_connection_rm.md
@@ -34,7 +34,7 @@ corectl connection rm ID-1 ID-2
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_connection_set.md
+++ b/docs/corectl_connection_set.md
@@ -32,7 +32,7 @@ corectl connection set ./my-connections.yml
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_dimension.md
+++ b/docs/corectl_dimension.md
@@ -22,7 +22,7 @@ Explore and manage dimensions
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_dimension_layout.md
+++ b/docs/corectl_dimension_layout.md
@@ -32,7 +32,7 @@ corectl dimension layout DIMENSION-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_dimension_ls.md
+++ b/docs/corectl_dimension_ls.md
@@ -32,7 +32,7 @@ corectl dimension ls
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_dimension_properties.md
+++ b/docs/corectl_dimension_properties.md
@@ -33,7 +33,7 @@ corectl dimension properties DIMENSION-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_dimension_rm.md
+++ b/docs/corectl_dimension_rm.md
@@ -33,7 +33,7 @@ corectl dimension rm ID-1
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_dimension_set.md
+++ b/docs/corectl_dimension_set.md
@@ -33,7 +33,7 @@ corectl dimension set ./my-dimensions-glob-path.json
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -35,7 +35,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_fields.md
+++ b/docs/corectl_fields.md
@@ -32,7 +32,7 @@ corectl fields
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_keys.md
+++ b/docs/corectl_keys.md
@@ -32,7 +32,7 @@ corectl keys
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_measure.md
+++ b/docs/corectl_measure.md
@@ -22,7 +22,7 @@ Explore and manage measures
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_measure_layout.md
+++ b/docs/corectl_measure_layout.md
@@ -32,7 +32,7 @@ corectl measure layout MEASURE-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_measure_ls.md
+++ b/docs/corectl_measure_ls.md
@@ -32,7 +32,7 @@ corectl measure ls
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_measure_properties.md
+++ b/docs/corectl_measure_properties.md
@@ -33,7 +33,7 @@ corectl measure properties MEASURE-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_measure_rm.md
+++ b/docs/corectl_measure_rm.md
@@ -33,7 +33,7 @@ corectl measure rm ID-1 ID-2
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_measure_set.md
+++ b/docs/corectl_measure_set.md
@@ -33,7 +33,7 @@ corectl measure set ./my-measures-glob-path.json
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_meta.md
+++ b/docs/corectl_meta.md
@@ -33,7 +33,7 @@ corectl meta --app my-app.qvf
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_object.md
+++ b/docs/corectl_object.md
@@ -22,7 +22,7 @@ Explore and manage generic objects
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_object_data.md
+++ b/docs/corectl_object_data.md
@@ -32,7 +32,7 @@ corectl object data OBJECT-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_object_layout.md
+++ b/docs/corectl_object_layout.md
@@ -32,7 +32,7 @@ corectl object layout OBJECT-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_object_ls.md
+++ b/docs/corectl_object_ls.md
@@ -32,7 +32,7 @@ corectl object ls
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_object_properties.md
+++ b/docs/corectl_object_properties.md
@@ -33,7 +33,7 @@ corectl object properties OBJECT-ID
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_object_rm.md
+++ b/docs/corectl_object_rm.md
@@ -33,7 +33,7 @@ corectl object rm ID-1 ID-2
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_object_set.md
+++ b/docs/corectl_object_set.md
@@ -34,7 +34,7 @@ corectl object set ./my-objects-glob-path.json
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -34,7 +34,7 @@ corectl reload
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_script.md
+++ b/docs/corectl_script.md
@@ -22,7 +22,7 @@ Explore and manage the script
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_script_get.md
+++ b/docs/corectl_script_get.md
@@ -32,7 +32,7 @@ corectl script get
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_script_set.md
+++ b/docs/corectl_script_set.md
@@ -33,7 +33,7 @@ corectl script set ./my-script-file.qvs
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_status.md
+++ b/docs/corectl_status.md
@@ -33,7 +33,7 @@ corectl status --app=my-app.qvf
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_tables.md
+++ b/docs/corectl_tables.md
@@ -33,7 +33,7 @@ corectl tables --app=my-app.qvf
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_values.md
+++ b/docs/corectl_values.md
@@ -32,7 +32,7 @@ corectl values FIELD
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -32,7 +32,7 @@ corectl version
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 ```
 

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -45,7 +45,7 @@
     },
     "ttl": {
       "description": "Qlik Associative Engine session time to live in seconds",
-      "default": "30"
+      "default": "0"
     },
     "verbose": {
       "alias": "v",

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -106,12 +106,13 @@ func verifyNoEntities(t *testing.T, connectToEngine string, configPath string, e
 func TestNestedObjectSupport(t *testing.T) {
 	connectToEngine := "--engine=" + *engineIP
 	//create the nested objects
-	output := setupEntities(connectToEngine, "--config=test/project2/corectl.yml", "object", "--objects=test/project2/sheet.json")
+	output := setupEntities(connectToEngine, "--config=test/project2/corectl-alt.yml", "object", "--objects=test/project2/sheet.json")
 
 	//verify that the objects are created
 	var objects []*enigma.NxInfo
 	err := json.Unmarshal(output, &objects)
 	assert.NoError(t, err)
+	assert.NotEmpty(t, objects)
 	assert.NotNil(t, objects[0])
 	assert.NotNil(t, objects[0].Id)
 	assert.Equal(t, "a699ee97-152d-4470-9655-ae7c82d71491", objects[0].Id)

--- a/test/golden/help-1.golden
+++ b/test/golden/help-1.golden
@@ -41,7 +41,7 @@ Flags:
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 
 Use "corectl [command] --help" for more information about a command.

--- a/test/golden/help-2.golden
+++ b/test/golden/help-2.golden
@@ -41,7 +41,7 @@ Flags:
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information
 
 Use "corectl [command] --help" for more information about a command.

--- a/test/golden/help-3.golden
+++ b/test/golden/help-3.golden
@@ -26,5 +26,5 @@ Global Flags:
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
   -t, --traffic                  Log JSON websocket traffic to stdout
-      --ttl string               Qlik Associative Engine session time to live in seconds (default "30")
+      --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/test/golden/project1-traffic-log.golden
+++ b/test/golden/project1-traffic-log.golden
@@ -1,9 +1,11 @@
-<-- {"jsonrpc":"2.0","method":"OnConnected","params":{"qSessionState":"SESSION_ATTACHED"}}
+<-- {"jsonrpc":"2.0","method":"OnConnected","params":{"qSessionState":"SESSION_CREATED"}}
 --> {"jsonrpc":"2.0","delta":false,"method":"GetActiveDoc","handle":-1,"id":1,"params":[]}
-<-- {"jsonrpc":"2.0","id":1,"result":{"qReturn":{"qType":"Doc","qHandle":1,"qGenericId":"/apps/corectl_test_app.qvf"}}}
---> {"jsonrpc":"2.0","delta":false,"method":"SetScript","handle":1,"id":2,"params":["LIB CONNECT TO myconnection;\n\nTableA:\nSELECT A;\n"]}
-<-- {"jsonrpc":"2.0","id":2,"result":{}}
-Saving app... --> {"jsonrpc":"2.0","delta":false,"method":"DoSave","handle":1,"id":3,"params":[""]}
-<-- {"jsonrpc":"2.0","id":3,"result":{},"change":[1]}
+<-- {"jsonrpc":"2.0","id":1,"error":{"code":1007,"parameter":"No active document","message":"App invalid"}}
+--> {"jsonrpc":"2.0","delta":false,"method":"OpenDoc","handle":-1,"id":2,"params":["/apps/corectl_test_app.qvf","","","",false]}
+<-- {"jsonrpc":"2.0","id":2,"result":{"qReturn":{"qType":"Doc","qHandle":1,"qGenericId":"/apps/corectl_test_app.qvf"}},"change":[1]}
+--> {"jsonrpc":"2.0","delta":false,"method":"SetScript","handle":1,"id":3,"params":["LIB CONNECT TO myconnection;\n\nTableA:\nSELECT A;\n"]}
+<-- {"jsonrpc":"2.0","id":3,"result":{}}
+Saving app... --> {"jsonrpc":"2.0","delta":false,"method":"DoSave","handle":1,"id":4,"params":[""]}
+<-- {"jsonrpc":"2.0","id":4,"result":{},"change":[1]}
 Done
 


### PR DESCRIPTION
Earlier the `ttl` was default set to 30 seconds, but since we are no longer using session apps this should instead default to 0.

Had to update some test cases that were dependant on previous test cases.