### PR TITLE
Handle app identifier in websocket url for catwalk command

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -122,10 +122,19 @@ var catwalkCmd = withLocalFlags(&cobra.Command{
 corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080`,
 
 	Run: func(ccmd *cobra.Command, args []string) {
-		catwalkURL := viper.GetString("catwalk-url") + "?engine_url=" + internal.TidyUpEngineURL(viper.GetString("engine")) + "/apps/" + viper.GetString("app")
+		var catwalkURL string
+		if viper.GetString("app") != "" {
+			catwalkURL = viper.GetString("catwalk-url") + "?engine_url=" + internal.TidyUpEngineURL(viper.GetString("engine")) + "/app/" + viper.GetString("app")
+		} else if internal.TryParseAppFromURL(viper.GetString("engine")) != "" {
+			catwalkURL = viper.GetString("catwalk-url") + "?engine_url=" + internal.TidyUpEngineURL(viper.GetString("engine"))
+		} else {
+			internal.FatalError("Please provide an app that should be opened in catwalk")
+		}
+
 		if !strings.HasPrefix(catwalkURL, "www") && !strings.HasPrefix(catwalkURL, "https://") && !strings.HasPrefix(catwalkURL, "http://") {
 			internal.FatalError("Please provide a valid URL starting with 'https://', 'http://' or 'www'")
 		}
+
 		err := browser.OpenURL(catwalkURL)
 		if err != nil {
 			internal.FatalError("Could not open URL", err)

--- a/internal/state.go
+++ b/internal/state.go
@@ -100,7 +100,7 @@ func PrepareEngineState(ctx context.Context, headers http.Header, createAppIfMis
 
 	if appName == "" {
 		// No app name provided, lets check if one exists in the url
-		appName = tryParseAppFromURL(engine)
+		appName = TryParseAppFromURL(engine)
 		if appName == "" {
 			FatalError("Error: No app specified")
 		}
@@ -272,8 +272,8 @@ func getSessionID(appID string) string {
 	return sessionID
 }
 
-// Function for parsing an url for an app identifier
-func tryParseAppFromURL(engineURL string) string {
+// TryParseAppFromURL parses an url for an app identifier
+func TryParseAppFromURL(engineURL string) string {
 	// Find any string in the path succeeding "/app/", and excluding anything after "/"
 	re, _ := regexp.Compile("/app/([^/]+)")
 	values := re.FindStringSubmatch(engineURL)

--- a/internal/state_test.go
+++ b/internal/state_test.go
@@ -28,15 +28,15 @@ func TestBuildEngineUrl(t *testing.T) {
 }
 
 func TestParseAppFromUrl(t *testing.T) {
-	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/app/test.qvf"), "test.qvf")
-	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/app/test.qvf/"), "test.qvf")
-	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/app/test.qvf/ttl/30"), "test.qvf")
-	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/test.qvf"), "test.qvf")
-	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/test.qvf/"), "test.qvf")
-	assert.Equal(t, tryParseAppFromURL("engine/sense/vp/app/test.qvf/"), "test.qvf")
-	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf/ttl/30"), "d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf")
-	assert.Equal(t, tryParseAppFromURL("ws://engine/sense/vp/app/d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf/ttl/30"), "d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf")
-	assert.Equal(t, tryParseAppFromURL("ws://engine/"), "")
-	assert.Equal(t, tryParseAppFromURL("ws://engine"), "")
-	assert.Equal(t, tryParseAppFromURL("ws://engine/sense"), "")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/sense/app/test.qvf"), "test.qvf")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/sense/app/test.qvf/"), "test.qvf")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/sense/app/test.qvf/ttl/30"), "test.qvf")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/sense/vp/app/test.qvf"), "test.qvf")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/sense/vp/app/test.qvf/"), "test.qvf")
+	assert.Equal(t, TryParseAppFromURL("engine/sense/vp/app/test.qvf/"), "test.qvf")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/sense/vp/app/d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf/ttl/30"), "d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/sense/vp/app/d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf/ttl/30"), "d6c281c1-3463-4b0a-8251-ed747e9e426e.qvf")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/"), "")
+	assert.Equal(t, TryParseAppFromURL("ws://engine"), "")
+	assert.Equal(t, TryParseAppFromURL("ws://engine/sense"), "")
 }


### PR DESCRIPTION
The `corectl catwalk` command was not working when an app name was provided in the engine url.