### PR TITLE
Add go mod tidy to renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "extends": [
     "qlik-oss",
     "qlik-oss:groupMinorPatch"
-  ]
+  ],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
Renovate updates dependencies for the go modules, but it does not run `go mod tidy` by default so we need to add it as a `postUpdateOptions`.

This closes #176 