### PR TITLE
Add flag for connecting to QSEfW with certificates

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -59,6 +59,7 @@ func initGlobalFlags(globalFlags *pflag.FlagSet) {
 	// not bound to viper
 	globalFlags.StringVarP(&explicitConfigFile, "config", "c", "", "path/to/config.yml where parameters can be set instead of on the command line")
 	globalFlags.StringToStringVar(&headersMap, "headers", nil, "Http headers to use when connecting to Qlik Associative Engine")
+	globalFlags.String("certificates", "", "path/to/certificates containing client and root certificates")
 
 	// Set annotation to run bash completion function
 	globalFlags.SetAnnotation("app", cobra.BashCompCustom, []string{"__corectl_get_apps"})

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -59,7 +59,7 @@ func initGlobalFlags(globalFlags *pflag.FlagSet) {
 	// not bound to viper
 	globalFlags.StringVarP(&explicitConfigFile, "config", "c", "", "path/to/config.yml where parameters can be set instead of on the command line")
 	globalFlags.StringToStringVar(&headersMap, "headers", nil, "Http headers to use when connecting to Qlik Associative Engine")
-	globalFlags.String("certificates", "", "path/to/certificates containing client and root certificates")
+	globalFlags.String("certificates", "", "path/to/folder containing client.pem, client_key.pem and root.pem certificates")
 
 	// Set annotation to run bash completion function
 	globalFlags.SetAnnotation("app", cobra.BashCompCustom, []string{"__corectl_get_apps"})

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -14,7 +14,7 @@ corectl [flags]
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -14,6 +14,7 @@ corectl [flags]
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_app.md
+++ b/docs/corectl_app.md
@@ -16,6 +16,7 @@ Explore and manage apps
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_app.md
+++ b/docs/corectl_app.md
@@ -16,7 +16,7 @@ Explore and manage apps
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_app_ls.md
+++ b/docs/corectl_app_ls.md
@@ -26,6 +26,7 @@ corectl app ls
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_app_ls.md
+++ b/docs/corectl_app_ls.md
@@ -26,7 +26,7 @@ corectl app ls
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_app_rm.md
+++ b/docs/corectl_app_rm.md
@@ -27,6 +27,7 @@ corectl app rm APP-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_app_rm.md
+++ b/docs/corectl_app_rm.md
@@ -27,7 +27,7 @@ corectl app rm APP-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_assoc.md
+++ b/docs/corectl_assoc.md
@@ -27,7 +27,7 @@ corectl associations
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_assoc.md
+++ b/docs/corectl_assoc.md
@@ -27,6 +27,7 @@ corectl associations
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -35,6 +35,7 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -35,7 +35,7 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -28,6 +28,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -28,7 +28,7 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_completion.md
+++ b/docs/corectl_completion.md
@@ -34,6 +34,7 @@ corectl completion <shell> [flags]
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_completion.md
+++ b/docs/corectl_completion.md
@@ -34,7 +34,7 @@ corectl completion <shell> [flags]
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_config.md
+++ b/docs/corectl_config.md
@@ -125,7 +125,7 @@ dimensions:
 
 ### certificates
 
-If you want to connect to a Qlik Sense Enterprise using certificates, it is possible to use the `certificates` parameter. By specifying a path to the folder containing the CA and root certificates, `corectl` will use the certificates when authenticating. `corectl` only supports connecting with `PEM` certificates and expects that `client.pem`, `client_key.pem` and `root.pem` to be present in the configured folder.
+If you want to connect to a Qlik Sense Enterprise using certificates, it is possible to use the `certificates` parameter. By specifying a path to the folder containing the CA and root certificates, `corectl` will use the certificates when authenticating. `corectl` only supports connecting with `PEM` certificates and expects `client.pem`, `client_key.pem` and `root.pem` to be present in the configured folder.
 
 ```yaml
 certificates: path/to/folder

--- a/docs/corectl_config.md
+++ b/docs/corectl_config.md
@@ -3,14 +3,14 @@
 With `corectl` it is possible to configure values that should be passed to your command. This can be configured in a `yaml` file residing in e.g. an repo or locally on your computer.
 By default `corectl` will pick up a `corectl.yml | corectl.yaml` file from your current directory. It is also possible to pass a specific configuration file using the `--config` or `-c` flag.
 
-All properties set in a configuration file can be overriden by passing another value as a flag instead. Properties can also be specified using environment variables. 
+All properties set in a configuration file can be overriden by passing another value as a flag instead. Properties can also be specified using environment variables.
 
 ### Configuration properties
 
 Below is a configuration example utilizing the different properties that are available today:
 
 ```yaml
-engine: localhost:9076 
+engine: localhost:9076
 app: project1.qvf
 script: script.qvs
 connections:
@@ -29,6 +29,7 @@ measures:
   - ./*measure*.json
 dimensions:
   - ./dimension-*.json
+certificates: path/to/certificates #path to the folder containing the root and client certificates
 headers:
   authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0" #generated at jwt.io with the password passw0rd
 ```
@@ -73,7 +74,7 @@ myfolderconnection:
     type: folder
 ```
 
-Depending on which type of connection that should be used there may be a need for additional values in your configuration. Below is another example where we configure an connection to a custom type connection e.g. a gRPC data connector. 
+Depending on which type of connection that should be used there may be a need for additional values in your configuration. Below is another example where we configure an connection to a custom type connection e.g. a gRPC data connector.
 
 When not specifying a `connectionstring` in your connection config then `corectl` builds one for you.
 The value for the `type` property will be set as `provider`, and the keys and values from the `settings` property will also be appended to the `connectionstring`. The example below will yield `CUSTOM CONNECT TO \"provider=testconnector;host=corectl-test-connector;\"`.
@@ -86,10 +87,10 @@ myconnection:
       host: corectl-test-connector
 ```
 
-#### Using a separate connections file 
-Optionally the `connections` property in the config file can reference a separate connections file by 
-specifying a path to a yaml file instead of an inline list of connections: 
-           
+#### Using a separate connections file
+Optionally the `connections` property in the config file can reference a separate connections file by
+specifying a path to a yaml file instead of an inline list of connections:
+
  ``` yaml
  connections: ./connections.yml
  ```
@@ -108,7 +109,7 @@ connections:
 ```
 
 Note that when using the `--connections` command line option only the file reference format is supported.
- 
+
 ### objects, measures and dimensions
 
 When for example generating apps it can be useful to create objects in an app from json files that are stored remotely or locally. The properties `objects`, `measures` and `dimensions` are arrays where you can set multiple files or using wildcards for paths to files. It is also possible to use nested json structures with this approach, and then multiple objects will be created in engine.
@@ -120,6 +121,14 @@ measures:
   - ./*measure*.json
 dimensions:
   - ./dimension-*.json
+```
+
+### certificates
+
+If you want to connect to a Qlik Sense Enterprise using certificates, it is possible to use the `certificates` parameter. By specifying a path to the folder containing the CA and root certificates, `corectl` will use the certificates when authenticating.
+
+```yaml
+certificates: path/to/folder
 ```
 
 ### headers

--- a/docs/corectl_config.md
+++ b/docs/corectl_config.md
@@ -125,11 +125,13 @@ dimensions:
 
 ### certificates
 
-If you want to connect to a Qlik Sense Enterprise using certificates, it is possible to use the `certificates` parameter. By specifying a path to the folder containing the CA and root certificates, `corectl` will use the certificates when authenticating.
+If you want to connect to a Qlik Sense Enterprise using certificates, it is possible to use the `certificates` parameter. By specifying a path to the folder containing the CA and root certificates, `corectl` will use the certificates when authenticating. `corectl` only supports connecting with `PEM` certificates and expects that `client.pem`, `client_key.pem` and `root.pem` to be present in the configured folder.
 
 ```yaml
 certificates: path/to/folder
 ```
+
+To specify which user that is connecting using the certificates you can add a `X-Qlik-User` header with value `UserDirectory=<user directory>; UserId=<user name>`. How to specify a header in the configuration file is described in the [headers](#headers) section.
 
 ### headers
 

--- a/docs/corectl_connection.md
+++ b/docs/corectl_connection.md
@@ -16,6 +16,7 @@ Explore and manage connections
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection.md
+++ b/docs/corectl_connection.md
@@ -16,7 +16,7 @@ Explore and manage connections
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection_get.md
+++ b/docs/corectl_connection_get.md
@@ -26,6 +26,7 @@ corectl connection get CONNECTION-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection_get.md
+++ b/docs/corectl_connection_get.md
@@ -26,7 +26,7 @@ corectl connection get CONNECTION-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection_ls.md
+++ b/docs/corectl_connection_ls.md
@@ -26,6 +26,7 @@ corectl connection ls
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection_ls.md
+++ b/docs/corectl_connection_ls.md
@@ -26,7 +26,7 @@ corectl connection ls
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection_rm.md
+++ b/docs/corectl_connection_rm.md
@@ -28,6 +28,7 @@ corectl connection rm ID-1 ID-2
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection_rm.md
+++ b/docs/corectl_connection_rm.md
@@ -28,7 +28,7 @@ corectl connection rm ID-1 ID-2
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection_set.md
+++ b/docs/corectl_connection_set.md
@@ -26,7 +26,7 @@ corectl connection set ./my-connections.yml
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_connection_set.md
+++ b/docs/corectl_connection_set.md
@@ -26,6 +26,7 @@ corectl connection set ./my-connections.yml
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension.md
+++ b/docs/corectl_dimension.md
@@ -16,6 +16,7 @@ Explore and manage dimensions
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension.md
+++ b/docs/corectl_dimension.md
@@ -16,7 +16,7 @@ Explore and manage dimensions
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_layout.md
+++ b/docs/corectl_dimension_layout.md
@@ -26,7 +26,7 @@ corectl dimension layout DIMENSION-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_layout.md
+++ b/docs/corectl_dimension_layout.md
@@ -26,6 +26,7 @@ corectl dimension layout DIMENSION-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_ls.md
+++ b/docs/corectl_dimension_ls.md
@@ -26,6 +26,7 @@ corectl dimension ls
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_ls.md
+++ b/docs/corectl_dimension_ls.md
@@ -26,7 +26,7 @@ corectl dimension ls
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_properties.md
+++ b/docs/corectl_dimension_properties.md
@@ -27,7 +27,7 @@ corectl dimension properties DIMENSION-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_properties.md
+++ b/docs/corectl_dimension_properties.md
@@ -27,6 +27,7 @@ corectl dimension properties DIMENSION-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_rm.md
+++ b/docs/corectl_dimension_rm.md
@@ -27,7 +27,7 @@ corectl dimension rm ID-1
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_rm.md
+++ b/docs/corectl_dimension_rm.md
@@ -27,6 +27,7 @@ corectl dimension rm ID-1
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_set.md
+++ b/docs/corectl_dimension_set.md
@@ -27,6 +27,7 @@ corectl dimension set ./my-dimensions-glob-path.json
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_dimension_set.md
+++ b/docs/corectl_dimension_set.md
@@ -27,7 +27,7 @@ corectl dimension set ./my-dimensions-glob-path.json
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -29,6 +29,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -29,7 +29,7 @@ corectl eval by "Region" // Returns the values for dimension "Region"
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_fields.md
+++ b/docs/corectl_fields.md
@@ -26,6 +26,7 @@ corectl fields
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_fields.md
+++ b/docs/corectl_fields.md
@@ -26,7 +26,7 @@ corectl fields
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_keys.md
+++ b/docs/corectl_keys.md
@@ -26,7 +26,7 @@ corectl keys
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_keys.md
+++ b/docs/corectl_keys.md
@@ -26,6 +26,7 @@ corectl keys
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure.md
+++ b/docs/corectl_measure.md
@@ -16,6 +16,7 @@ Explore and manage measures
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure.md
+++ b/docs/corectl_measure.md
@@ -16,7 +16,7 @@ Explore and manage measures
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_layout.md
+++ b/docs/corectl_measure_layout.md
@@ -26,7 +26,7 @@ corectl measure layout MEASURE-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_layout.md
+++ b/docs/corectl_measure_layout.md
@@ -26,6 +26,7 @@ corectl measure layout MEASURE-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_ls.md
+++ b/docs/corectl_measure_ls.md
@@ -26,7 +26,7 @@ corectl measure ls
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_ls.md
+++ b/docs/corectl_measure_ls.md
@@ -26,6 +26,7 @@ corectl measure ls
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_properties.md
+++ b/docs/corectl_measure_properties.md
@@ -27,6 +27,7 @@ corectl measure properties MEASURE-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_properties.md
+++ b/docs/corectl_measure_properties.md
@@ -27,7 +27,7 @@ corectl measure properties MEASURE-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_rm.md
+++ b/docs/corectl_measure_rm.md
@@ -27,7 +27,7 @@ corectl measure rm ID-1 ID-2
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_rm.md
+++ b/docs/corectl_measure_rm.md
@@ -27,6 +27,7 @@ corectl measure rm ID-1 ID-2
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_set.md
+++ b/docs/corectl_measure_set.md
@@ -27,6 +27,7 @@ corectl measure set ./my-measures-glob-path.json
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_measure_set.md
+++ b/docs/corectl_measure_set.md
@@ -27,7 +27,7 @@ corectl measure set ./my-measures-glob-path.json
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_meta.md
+++ b/docs/corectl_meta.md
@@ -27,6 +27,7 @@ corectl meta --app my-app.qvf
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_meta.md
+++ b/docs/corectl_meta.md
@@ -27,7 +27,7 @@ corectl meta --app my-app.qvf
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object.md
+++ b/docs/corectl_object.md
@@ -16,6 +16,7 @@ Explore and manage generic objects
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object.md
+++ b/docs/corectl_object.md
@@ -16,7 +16,7 @@ Explore and manage generic objects
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_data.md
+++ b/docs/corectl_object_data.md
@@ -26,6 +26,7 @@ corectl object data OBJECT-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_data.md
+++ b/docs/corectl_object_data.md
@@ -26,7 +26,7 @@ corectl object data OBJECT-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_layout.md
+++ b/docs/corectl_object_layout.md
@@ -26,7 +26,7 @@ corectl object layout OBJECT-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_layout.md
+++ b/docs/corectl_object_layout.md
@@ -26,6 +26,7 @@ corectl object layout OBJECT-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_ls.md
+++ b/docs/corectl_object_ls.md
@@ -26,7 +26,7 @@ corectl object ls
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_ls.md
+++ b/docs/corectl_object_ls.md
@@ -26,6 +26,7 @@ corectl object ls
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_properties.md
+++ b/docs/corectl_object_properties.md
@@ -27,7 +27,7 @@ corectl object properties OBJECT-ID
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_properties.md
+++ b/docs/corectl_object_properties.md
@@ -27,6 +27,7 @@ corectl object properties OBJECT-ID
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_rm.md
+++ b/docs/corectl_object_rm.md
@@ -27,7 +27,7 @@ corectl object rm ID-1 ID-2
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_rm.md
+++ b/docs/corectl_object_rm.md
@@ -27,6 +27,7 @@ corectl object rm ID-1 ID-2
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_set.md
+++ b/docs/corectl_object_set.md
@@ -28,6 +28,7 @@ corectl object set ./my-objects-glob-path.json
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_object_set.md
+++ b/docs/corectl_object_set.md
@@ -28,7 +28,7 @@ corectl object set ./my-objects-glob-path.json
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -28,6 +28,7 @@ corectl reload
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -28,7 +28,7 @@ corectl reload
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_script.md
+++ b/docs/corectl_script.md
@@ -16,6 +16,7 @@ Explore and manage the script
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_script.md
+++ b/docs/corectl_script.md
@@ -16,7 +16,7 @@ Explore and manage the script
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_script_get.md
+++ b/docs/corectl_script_get.md
@@ -26,7 +26,7 @@ corectl script get
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_script_get.md
+++ b/docs/corectl_script_get.md
@@ -26,6 +26,7 @@ corectl script get
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_script_set.md
+++ b/docs/corectl_script_set.md
@@ -27,6 +27,7 @@ corectl script set ./my-script-file.qvs
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_script_set.md
+++ b/docs/corectl_script_set.md
@@ -27,7 +27,7 @@ corectl script set ./my-script-file.qvs
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_status.md
+++ b/docs/corectl_status.md
@@ -27,7 +27,7 @@ corectl status --app=my-app.qvf
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_status.md
+++ b/docs/corectl_status.md
@@ -27,6 +27,7 @@ corectl status --app=my-app.qvf
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_tables.md
+++ b/docs/corectl_tables.md
@@ -27,6 +27,7 @@ corectl tables --app=my-app.qvf
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_tables.md
+++ b/docs/corectl_tables.md
@@ -27,7 +27,7 @@ corectl tables --app=my-app.qvf
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_values.md
+++ b/docs/corectl_values.md
@@ -26,6 +26,7 @@ corectl values FIELD
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_values.md
+++ b/docs/corectl_values.md
@@ -26,7 +26,7 @@ corectl values FIELD
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -26,6 +26,7 @@ corectl version
 
 ```
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -26,7 +26,7 @@ corectl version
 
 ```
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -17,6 +17,9 @@
       "description": "Bash flag used to adapt output to bash completion format",
       "default": "false"
     },
+    "certificates": {
+      "description": "path/to/certificates containing client and root certificates"
+    },
     "config": {
       "alias": "c",
       "description": "path/to/config.yml where parameters can be set instead of on the command line"

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -18,7 +18,7 @@
       "default": "false"
     },
     "certificates": {
-      "description": "path/to/certificates containing client and root certificates"
+      "description": "path/to/folder containing client.pem, client_key.pem and root.pem certificates"
     },
     "config": {
       "alias": "c",

--- a/internal/state.go
+++ b/internal/state.go
@@ -55,10 +55,16 @@ func connectToEngine(ctx context.Context, engine string, appName string, ttl str
 	}
 	LogVerbose("SessionId " + headers.Get("X-Qlik-Session"))
 
+	certificates := viper.GetString("certificates")
+
 	var dialer = enigma.Dialer{}
 
 	if LogTraffic {
 		dialer.TrafficLogger = TrafficLogger{}
+	}
+
+	if certificates != "" {
+		dialer.TLSClientConfig = readCertificates(certificates)
 	}
 
 	global, err := dialer.Dial(ctx, engineURL, headers)

--- a/internal/state.go
+++ b/internal/state.go
@@ -304,14 +304,12 @@ func readCertificates(certificatesPath string) *tls.Config {
 
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		fmt.Println("Failed to load client certificate", err)
-		panic(err)
+		FatalError("Failed to load client certificate: ", err)
 	}
 
 	caCert, err := ioutil.ReadFile(caFile)
 	if err != nil {
-		fmt.Println("Failed to read root certificate", err)
-		panic(err)
+		FatalError("Failed to read root certificate: ", err)
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)

--- a/test/golden/TestHelp_#00.golden
+++ b/test/golden/TestHelp_#00.golden
@@ -34,7 +34,7 @@ Other Commands:
 
 Flags:
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/test/golden/TestHelp_#00.golden
+++ b/test/golden/TestHelp_#00.golden
@@ -34,6 +34,7 @@ Other Commands:
 
 Flags:
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/test/golden/TestHelp_help.golden
+++ b/test/golden/TestHelp_help.golden
@@ -34,7 +34,7 @@ Other Commands:
 
 Flags:
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/test/golden/TestHelp_help.golden
+++ b/test/golden/TestHelp_help.golden
@@ -34,6 +34,7 @@ Other Commands:
 
 Flags:
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/test/golden/TestHelp_help_build.golden
+++ b/test/golden/TestHelp_help_build.golden
@@ -20,6 +20,7 @@ Flags:
 
 Global Flags:
   -a, --app string               Name or identifier of the app
+      --certificates string      path/to/certificates containing client and root certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])

--- a/test/golden/TestHelp_help_build.golden
+++ b/test/golden/TestHelp_help_build.golden
@@ -20,7 +20,7 @@ Flags:
 
 Global Flags:
   -a, --app string               Name or identifier of the app
-      --certificates string      path/to/certificates containing client and root certificates
+      --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
   -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])


### PR DESCRIPTION
This PR adds a flag `certificates` that can be configured to a folder containing root and client certificates. This enables connecting to a QSEfW Engine and bypassing the proxy.

This closes #299 