### PR TITLE
Hide bookmark set

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ tag as version and then generate the spec using:
 
 ```bash
 go build -ldflags "-X main.version=$(git describe --tag --abbrev=0)"
-./corectl generate-spec > docs/spec.json
+./corectl generate-spec
 ```
 
 ## Contributing

--- a/cmd/bookmark.go
+++ b/cmd/bookmark.go
@@ -13,6 +13,7 @@ var setBookmarksCmd = withLocalFlags(&cobra.Command{
 	Short:   "Set or update the bookmarks in the current app",
 	Long:    "Set or update the bookmarks in the current app",
 	Example: "corectl bookmark set ./my-bookmarks-glob-path.json",
+	Hidden: true,
 
 	Run: func(ccmd *cobra.Command, args []string) {
 		commandLineBookmarks := args[0]
@@ -96,6 +97,7 @@ var bookmarkCmd = &cobra.Command{
 	Long:		"Explore and manage bookmarks",
 	Annotations: map[string]string{
 		"command_category": "sub",
+		"x-qlik-stability": "experimental",
 	},
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -29,7 +29,6 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs`,
 		internal.SetVariables(ctx, state.Doc, ccmd.Flag("variables").Value.String())
 		internal.SetMeasures(ctx, state.Doc, ccmd.Flag("measures").Value.String())
 		internal.SetObjects(ctx, state.Doc, ccmd.Flag("objects").Value.String())
-		internal.SetBookmarks(ctx, state.Doc, ccmd.Flag("bookmarks").Value.String())
 		scriptFile := ccmd.Flag("script").Value.String()
 		if scriptFile == "" {
 			scriptFile = getPathFlagFromConfigFile("script")

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -119,7 +120,7 @@ var generateSpecCmd = &cobra.Command{
 		if err != nil {
 			fmt.Println(err)
 		}
-		fmt.Println(string(jsonData))
+		ioutil.WriteFile("./docs/spec.json", jsonData, 0644)
 	},
 }
 

--- a/cmd/variable.go
+++ b/cmd/variable.go
@@ -96,6 +96,7 @@ var variableCmd = &cobra.Command{
 	Long:  "Explore and manage variables",
 	Annotations: map[string]string{
 		"command_category": "sub",
+		"x-qlik-stability": "experimental",
 	},
 }
 

--- a/docs/corectl_bookmark.md
+++ b/docs/corectl_bookmark.md
@@ -34,5 +34,4 @@ Explore and manage bookmarks
 * [corectl bookmark ls](corectl_bookmark_ls.md)	 - Print a list of all generic bookmarks in the current app
 * [corectl bookmark properties](corectl_bookmark_properties.md)	 - Print the properties of the generic bookmark
 * [corectl bookmark rm](corectl_bookmark_rm.md)	 - Remove one or many bookmarks in the current app
-* [corectl bookmark set](corectl_bookmark_set.md)	 - Set or update the bookmarks in the current app
 

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -80,6 +80,7 @@
     },
     "bookmark": {
       "description": "Explore and manage bookmarks",
+      "x-qlik-stability": "experimental",
       "commands": {
         "layout": {
           "description": "Evaluate the layout of an generic bookmark"
@@ -368,6 +369,7 @@
     },
     "variable": {
       "description": "Explore and manage variables",
+      "x-qlik-stability": "experimental",
       "commands": {
         "layout": {
           "description": "Evaluate the layout of an generic variable"

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -151,6 +151,7 @@ func TestBookmarkManagementCommands(t *testing.T) {
 
 	// Build with two bookmarks
 	p.ExpectOK().Run("build")
+	p.ExpectOK().Run("bookmark", "set", "test/projects/using-entities/bookmarks.json")
 	p.ExpectOK().Run("bookmark", "ls") // Cannot ensure order of bookmarks so can't use golden.
 	p.ExpectOK().Run("bookmark", "ls", "--json")
 	p.ExpectOK().Run("bookmark", "ls", "--bash")


### PR DESCRIPTION
`bookmark set` is now hidden because a bookmark cannot be fully created through APIs, meaning that the command might not behave as expected.

Also marked variable and bookmark as experimental as well as changed so that `generate-spec` works as `generate-docs`. (You don't have to pipe the output to a file.)