### PR TITLE
Publish brew tap formula using goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,34 +9,58 @@ builds:
   goarch:
     - amd64
 
-archive:
-  name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    amd64: x86_64
-  format: tar.gz
-  format_overrides:
-    - goos: windows
-      format: zip
-  files:
-  - none*
+archives:
+  -
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+    - none*
 
-snapcraft:
-  name_template: "qlik-{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
-  name: qlik-corectl
+snapcrafts:
+  -
+    name_template: "qlik-{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
+    name: qlik-corectl
 
-  publish: true
+    publish: true
 
-  summary: A command line interface tool for the Qlik Associative Engine
-  description: |
-    Qlik Core Control (corectl) is a tool that delivers a
-    command line interface (CLI) for the Qlik Associative Engine.
-    With corectl you can interact with your apps, objects, and data.
-  grade: stable
-  confinement: strict
+    summary: A command line interface tool for the Qlik Associative Engine
+    description: |
+      Qlik Core Control (corectl) is a tool that delivers a
+      command line interface (CLI) for the Qlik Associative Engine.
+      With corectl you can interact with your apps, objects, and data.
+    grade: stable
+    confinement: strict
 
-  apps:
-    corectl:
-      plugs: ["home", "network"]
+    apps:
+      corectl:
+        plugs: ["home", "network"]
+
+brews:
+  -
+    github:
+      owner: qlik-oss
+      name: homebrew-taps
+
+    commit_author:
+      name: qlikossbuild
+      email: qlikossbuild@qlik.com
+
+    folder: Formula
+
+    homepage: "https://github.com/qlik-oss/corectl"
+
+    description: "corectl is a CLI tool for using Qlik Associative Engine."
+
+    test: |
+      assert_equal corectl version: '#{version}", shell_output("#{bin}/corectl version").chomp"'
+
+    install: |
+      bin.install "corectl"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,8 @@ snapcrafts:
 
 brews:
   -
+    name: qlik-corectl
+
     github:
       owner: qlik-oss
       name: homebrew-taps
@@ -60,7 +62,7 @@ brews:
     description: "corectl is a CLI tool for using Qlik Associative Engine."
 
     test: |
-      assert_equal corectl version: '#{version}", shell_output("#{bin}/corectl version").chomp"'
+      assert_equal "corectl version: #{version}", shell_output("#{bin}/corectl version").chomp
 
     install: |
       bin.install "corectl"


### PR DESCRIPTION
This PR adds a config for updating the formula in the `homebrew-taps` repo when a new version of corectl is released. I haven't found any way to verify the generated formula locally using snapshot, but the configuration seems fairly straightforward.

Also changed the sections for `archive` and `snapcraft` which were deprecated.

https://goreleaser.com/customization/#Homebrew