### PR TITLE
Circleci linting fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,13 @@ jobs:
           name: Linting
           command: |
             go fmt ./...
-            git diff --exit-code
             go get -u golang.org/x/lint/golint
             golint -set_exit_status
-            # golint adds stuff to go.mod and go.sum that mess
-            # with git status --porcelain later
+            # go fmt and golint can alter go.mod and go.sum,
+            # this will cause the git diff to give false negative
+            # restore those files before proceeding
             git checkout go.mod go.sum
+            git diff --exit-code
       - run:
           name: Test
           command: go test -v -race ./...


### PR DESCRIPTION
`go fmt ./...` installed dependencies in `go.mod` and since we run `git diff` directly after this caused a renovate job to fail. I changed so that any dependencies install by either `go fmt` or `golint` should not interfere with the linting itself.