### PR TITLE
Fixed go.mod and go.sum problem in circleci build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,11 @@ jobs:
             git diff --exit-code
       - run:
           name: Test
-          command: go test -v -race ./...
+          command: |
+            go test -v -race ./...
+            # go test can also modify go.mod and go.sum, ruining
+            # the pristine state required for our tests to pass
+            git checkout go.mod go.sum
       - run:
           name: Check if documentation needs to be updated
           command: |


### PR DESCRIPTION
Identical problem as in #368 but here with `go test` instead. It appears that many go tools use the `go-github` library but have yet to update to the latest version.