### PR TITLE
Context can now get cert from flags, with abs path

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -60,10 +60,10 @@ func initGlobalFlags(globalFlags *pflag.FlagSet) {
 		viper.BindPFlag(flag.Name, flag)
 	})
 
-	// not bound to viper
+	// Not bound to viper. Certificates are handled similarly to config as the path might be relative.
 	globalFlags.StringVarP(&explicitConfigFile, "config", "c", "", "path/to/config.yml where parameters can be set instead of on the command line")
 	globalFlags.StringToStringVar(&headersMap, "headers", nil, "Http headers to use when connecting to Qlik Associative Engine")
-	globalFlags.String("certificates", "", "path/to/folder containing client.pem, client_key.pem and root.pem certificates")
+	globalFlags.StringVar(&explicitCertificatePath, "certificates", "", "path/to/folder containing client.pem, client_key.pem and root.pem certificates")
 
 	// Set annotation to run bash completion function
 	globalFlags.SetAnnotation("app", cobra.BashCompCustom, []string{"__corectl_get_apps"})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 var headersMap = make(map[string]string)
 var explicitConfigFile = ""
+var explicitCertificatePath = ""
 var version = ""
 var headers http.Header
 var certificates *tls.Config
@@ -39,14 +40,9 @@ var rootCmd = &cobra.Command{
 		}
 		// Depending on the command, we might not want to use context when loading config.
 		withContext := shouldUseContext(ccmd)
-		internal.ReadConfig(explicitConfigFile, withContext)
+		internal.ReadConfig(explicitConfigFile, explicitCertificatePath, withContext)
 
-		// Check if certificates are specified with a flag or defined in config
-		certPath := ccmd.Flag("certificates").Value.String()
-		if certPath == "" {
-			certPath = getPathFlagFromConfigFile("certificates")
-		}
-		if certPath != "" {
+		if certPath := viper.GetString("certificates"); certPath != "" {
 			certificates = internal.ReadCertificates(certPath)
 		}
 

--- a/internal/context.go
+++ b/internal/context.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -50,12 +49,6 @@ func SetContext(contextName, comment string) string {
 	} else {
 		context = &Context{}
 		LogVerbose("Creating context: " + contextName)
-	}
-
-	// Check if certificates should be added, if so we should add them with an absolute path
-	certificates := viper.GetString("certificates")
-	if certificates != "" {
-		certificates, _ = filepath.Abs(certificates)
 	}
 
 	updated := context.Update(&map[string]interface{}{

--- a/internal/context.go
+++ b/internal/context.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -51,10 +52,16 @@ func SetContext(contextName, comment string) string {
 		LogVerbose("Creating context: " + contextName)
 	}
 
+	// Check if certificates should be added, if so we should add them with an absolute path
+	certificates := viper.GetString("certificates")
+	if certificates != "" {
+		certificates, _ = filepath.Abs(certificates)
+	}
+
 	updated := context.Update(&map[string]interface{}{
 		"engine":       viper.GetString("engine"),
 		"headers":      viper.GetStringMapString("headers"),
-		"certificates": viper.GetString("certificates"),
+		"certificates": certificates,
 		"comment":      comment,
 	})
 

--- a/internal/context.go
+++ b/internal/context.go
@@ -61,7 +61,7 @@ func SetContext(contextName, comment string) string {
 	updated := context.Update(&map[string]interface{}{
 		"engine":       viper.GetString("engine"),
 		"headers":      viper.GetStringMapString("headers"),
-		"certificates": certificates,
+		"certificates": viper.GetString("certificates"),
 		"comment":      comment,
 	})
 


### PR DESCRIPTION
Fixed some issues regarding absolute paths and certificates, as well as changed how the certificate flag is used. It is now used similarly to how the config flag is used.