### PR TITLE
docs: Add commit guidelines and restrict prefix in goreleaser

### DIFF
--- a/.github/GUIDELINES.md
+++ b/.github/GUIDELINES.md
@@ -1,0 +1,19 @@
+# Commit message guidelines
+
+Commit messages should follow the [commit message convention](https://conventionalcommits.org/).
+
+## Type
+
+Should be one of the following:
+
+- **build:** Changes that affect the build system or external dependencies
+- **chore:** Changes to build and dev processes/tools
+- **ci:** Changes to the CI configuration files and scripts
+- **docs:** Changes to documentation
+- **feat:** A new feature
+- **fix:** A bug fix
+- **perf:** A code change that improves performance
+- **refactor:** Changes to production code that is neither a new feature nor a bug fix
+- **revert:** Reverts a previous commit
+- **style:** Changes to code style formatting (white space, commas etc)
+- **test:** Changes in test cases of production code

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+**Checklist**
+
+- [ ] tests added
+- [ ] commits conform to the [commit guidelines](./GUIDELINES.md#type)
+- [ ] documentation updated

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,11 +26,8 @@ archives:
 
 changelog:
   filters:
-    exclude:
-      - '^Update .+ commit hash to'
-      - '^Update module .+ to'
-      - '^Automated: Bump Docker images$'
-      - '^Release v\d\.\d\.\d(-\w+)?$'
+    include:
+      - '^(feat|fix|perf):'
 
 snapcrafts:
   -


### PR DESCRIPTION
This PR adds commit guidelines for creating a PR which also includes specifying a commit prefix that can be included/excluded by `goreleaser`. Same approach as used in `picasso.js`.

This closes #369 