### PR TITLE
Run SetProperties in parallel when updating multiple objects

### DIFF
--- a/internal/object.go
+++ b/internal/object.go
@@ -43,13 +43,12 @@ func ListObjects(ctx context.Context, doc *enigma.Doc) []NamedItemWithType {
 	allInfos, _ := doc.GetAllInfos(ctx)
 	unsortedResult := make(map[string]*NamedItemWithType)
 	resultInAlphabeticalOrder := []NamedItemWithType{}
-	keys := make([]string, 0, len(allInfos))
+	keys := []string{}
 
 	waitChannel := make(chan *NamedItemWithType)
 	defer close(waitChannel)
 
 	for _, item := range allInfos {
-		keys = append(keys, item.Id)
 		go func(item *enigma.NxInfo) {
 			object, _ := doc.GetObject(ctx, item.Id)
 			if object != nil && object.Type != "" {
@@ -66,15 +65,14 @@ func ListObjects(ctx context.Context, doc *enigma.Doc) []NamedItemWithType {
 	for range allInfos {
 		item := <-waitChannel
 		if item != nil {
+			keys = append(keys, item.Id)
 			unsortedResult[item.Id] = item
 		}
 	}
 	//Loop over the keys that are sorted in alphabetical order and fetch the result for each object
 	sort.Strings(keys)
 	for _, key := range keys {
-		if unsortedResult[key] != nil {
-			resultInAlphabeticalOrder = append(resultInAlphabeticalOrder, *unsortedResult[key])
-		}
+		resultInAlphabeticalOrder = append(resultInAlphabeticalOrder, *unsortedResult[key])
 	}
 	return resultInAlphabeticalOrder
 }

--- a/internal/object.go
+++ b/internal/object.go
@@ -42,7 +42,6 @@ func (o Object) validate() error {
 func ListObjects(ctx context.Context, doc *enigma.Doc) []NamedItemWithType {
 	allInfos, _ := doc.GetAllInfos(ctx)
 	unsortedResult := make(map[string]*NamedItemWithType)
-	resultInSortedOrder := []NamedItemWithType{}
 	keys := []string{}
 
 	waitChannel := make(chan *NamedItemWithType)
@@ -71,8 +70,9 @@ func ListObjects(ctx context.Context, doc *enigma.Doc) []NamedItemWithType {
 	}
 	//Loop over the keys that are sorted on qId and fetch the result for each object
 	sort.Strings(keys)
-	for _, key := range keys {
-		resultInSortedOrder = append(resultInSortedOrder, *unsortedResult[key])
+	resultInSortedOrder := make([]NamedItemWithType, len(keys))
+	for i, key := range keys {
+		resultInSortedOrder[i] = *unsortedResult[key]
 	}
 	return resultInSortedOrder
 }

--- a/test/golden/TestChildObjectsAndFullPropertyTree_object_ls_--json.golden
+++ b/test/golden/TestChildObjectsAndFullPropertyTree_object_ls_--json.golden
@@ -5,12 +5,12 @@
     "title": ""
   },
   {
-    "qId": "sZAVcpj",
+    "qId": "gCCkr",
     "qType": "auto-chart",
     "title": ""
   },
   {
-    "qId": "gCCkr",
+    "qId": "sZAVcpj",
     "qType": "auto-chart",
     "title": ""
   }


### PR DESCRIPTION
When running e.g. the `build` command creation/updating of objects were done sequentially. This PR changes so it is done in parallel instead. Since we want the output of `object ls` to be deterministic, I have also changed so the returned objects are sorted in alphabetical order on `qId`.

This closes #410 