### PR TITLE
Create and update dimensions and measures in parallel

### DIFF
--- a/internal/dimension.go
+++ b/internal/dimension.go
@@ -105,7 +105,7 @@ func SetDimensions(ctx context.Context, doc *enigma.Doc, commandLineGlobPattern 
 		}
 
 		if !success {
-			FatalError("One or more measures failed to be created or updated")
+			FatalError("One or more dimensions failed to be created or updated")
 		}
 	}
 }

--- a/internal/dimension.go
+++ b/internal/dimension.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/qlik-oss/enigma-go"
 )
 
+// Dimension is a struct describing a generic dimension
 type Dimension struct {
 	Info *enigma.NxInfo `json:"qInfo,omitempty"`
 }
@@ -46,13 +48,22 @@ func ListDimensions(ctx context.Context, doc *enigma.Doc) []NamedItem {
 	sessionObject, _ := doc.CreateSessionObject(ctx, props)
 	defer doc.DestroySessionObject(ctx, sessionObject.GenericId)
 	layout, _ := sessionObject.GetLayout(ctx)
-	result := []NamedItem{}
+	unsortedResult := make(map[string]*NamedItem)
+	keys := make([]string, len(unsortedResult))
 	for _, item := range layout.DimensionList.Items {
 		parsedRawData := &ParsedEntityListData{}
 		json.Unmarshal(item.Data, parsedRawData)
-		result = append(result, NamedItem{Title: parsedRawData.Title, Id: item.Info.Id})
+		unsortedResult[item.Info.Id] = &NamedItem{Title: parsedRawData.Title, Id: item.Info.Id}
+		keys = append(keys, item.Info.Id)
 	}
-	return result
+
+	//Loop over the keys that are sorted on qId and fetch the result for each object
+	sort.Strings(keys)
+	sortedResult := make([]NamedItem, len(keys))
+	for i, key := range keys {
+		sortedResult[i] = *unsortedResult[key]
+	}
+	return sortedResult
 }
 
 // SetDimensions adds all dimensions that match the specified glob pattern
@@ -66,20 +77,35 @@ func SetDimensions(ctx context.Context, doc *enigma.Doc, commandLineGlobPattern 
 		if err != nil {
 			FatalErrorf("could not parse file %s: %s", path, err)
 		}
+		ch := make(chan error)
+
 		for _, raw := range rawEntities {
-			var dim Dimension
-			err := json.Unmarshal(raw, &dim)
+			go func(raw json.RawMessage) {
+				var dim Dimension
+				err := json.Unmarshal(raw, &dim)
+				if err != nil {
+					ch <- fmt.Errorf("could not parse data in file %s: %s", path, err)
+				}
+				err = dim.validate()
+				if err != nil {
+					ch <- fmt.Errorf("validation error in file %s: %s", path, err)
+				}
+				ch <- setDimension(ctx, doc, dim.Info.Id, raw)
+			}(raw)
+		}
+
+		// Loop through the responses and see if there are any failures, if so exit with a fatal
+		success := true
+		for range rawEntities {
+			err := <-ch
 			if err != nil {
-				FatalErrorf("could not parse data in file %s: %s", path, err)
+				fmt.Printf("ERROR " + err.Error())
+				success = false
 			}
-			err = dim.validate()
-			if err != nil {
-				FatalErrorf("validation error in file %s: %s", path, err)
-			}
-			err = setDimension(ctx, doc, dim.Info.Id, raw)
-			if err != nil {
-				FatalError(err)
-			}
+		}
+
+		if !success {
+			FatalError("One or more measures failed to be created or updated")
 		}
 	}
 }

--- a/internal/measure.go
+++ b/internal/measure.go
@@ -74,13 +74,13 @@ func SetMeasures(ctx context.Context, doc *enigma.Doc, commandLineGlobPattern st
 		FatalError("could not interpret glob pattern: ", err)
 	}
 
-	ch := make(chan error)
-
 	for _, path := range paths {
 		rawEntities, err := parseEntityFile(path)
 		if err != nil {
 			FatalErrorf("could not parse file %s: %s", path, err)
 		}
+		ch := make(chan error)
+
 		for _, raw := range rawEntities {
 			go func(raw json.RawMessage) {
 				var measure Measure

--- a/internal/measure.go
+++ b/internal/measure.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/qlik-oss/enigma-go"
 )
 
+// Measure is a struct describing a generic measure
 type Measure struct {
 	Info *enigma.NxInfo `json:"qInfo,omitempty"`
 }
@@ -29,6 +31,7 @@ func (m Measure) validate() error {
 	return nil
 }
 
+// ListMeasures fetches all measures and returns them in an array
 func ListMeasures(ctx context.Context, doc *enigma.Doc) []NamedItem {
 	props := &enigma.GenericObjectProperties{
 		Info: &enigma.NxInfo{
@@ -45,39 +48,66 @@ func ListMeasures(ctx context.Context, doc *enigma.Doc) []NamedItem {
 	sessionObject, _ := doc.CreateSessionObject(ctx, props)
 	defer doc.DestroySessionObject(ctx, sessionObject.GenericId)
 	layout, _ := sessionObject.GetLayout(ctx)
-	result := []NamedItem{}
+
+	unsortedResult := make(map[string]*NamedItem)
+	keys := make([]string, len(unsortedResult))
 	for _, item := range layout.MeasureList.Items {
 		parsedRawData := &ParsedEntityListData{}
 		json.Unmarshal(item.Data, parsedRawData)
-		result = append(result, NamedItem{Title: parsedRawData.Title, Id: item.Info.Id})
+		unsortedResult[item.Info.Id] = &NamedItem{Title: parsedRawData.Title, Id: item.Info.Id}
+		keys = append(keys, item.Info.Id)
 	}
-	return result
+
+	//Loop over the keys that are sorted on qId and fetch the result for each object
+	sort.Strings(keys)
+	sortedResult := make([]NamedItem, len(keys))
+	for i, key := range keys {
+		sortedResult[i] = *unsortedResult[key]
+	}
+	return sortedResult
 }
 
+// SetMeasures creates or updates all measures on given glob patterns
 func SetMeasures(ctx context.Context, doc *enigma.Doc, commandLineGlobPattern string) {
 	paths, err := getEntityPaths(commandLineGlobPattern, "measures")
 	if err != nil {
 		FatalError("could not interpret glob pattern: ", err)
 	}
+
+	ch := make(chan error)
+
 	for _, path := range paths {
 		rawEntities, err := parseEntityFile(path)
 		if err != nil {
 			FatalErrorf("could not parse file %s: %s", path, err)
 		}
 		for _, raw := range rawEntities {
-			var measure Measure
-			err := json.Unmarshal(raw, &measure)
+			go func(raw json.RawMessage) {
+				var measure Measure
+				err := json.Unmarshal(raw, &measure)
+				if err != nil {
+					ch <- fmt.Errorf("could not parse data in file %s: %s", path, err)
+				}
+				err = measure.validate()
+				if err != nil {
+					ch <- fmt.Errorf("validation error in file %s: %s", path, err)
+				}
+				ch <- setMeasure(ctx, doc, measure.Info.Id, raw)
+			}(raw)
+		}
+
+		// Loop through the responses and see if there are any failures, if so exit with a fatal
+		success := true
+		for range rawEntities {
+			err := <-ch
 			if err != nil {
-				FatalErrorf("could not parse data in file %s: %s", path, err)
+				fmt.Printf("ERROR " + err.Error())
+				success = false
 			}
-			err = measure.validate()
-			if err != nil {
-				FatalErrorf("validation error in file %s: %s", path, err)
-			}
-			err = setMeasure(ctx, doc, measure.Info.Id, raw)
-			if err != nil {
-				FatalError(err)
-			}
+		}
+
+		if !success {
+			FatalError("One or more measures failed to be created or updated")
 		}
 	}
 }

--- a/internal/object.go
+++ b/internal/object.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qlik-oss/enigma-go"
 )
 
+// Object is a struct describing the generic object
 type Object struct {
 	Info       *enigma.NxInfo                  `json:"qInfo,omitempty"`
 	Properties *enigma.GenericObjectProperties `json:"qProperty,omitempty"`
@@ -39,6 +40,7 @@ func (o Object) validate() error {
 	return nil
 }
 
+// ListObjects fetches all generic objects and returns them sorted in an array
 func ListObjects(ctx context.Context, doc *enigma.Doc) []NamedItemWithType {
 	allInfos, _ := doc.GetAllInfos(ctx)
 	unsortedResult := make(map[string]*NamedItemWithType)

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -165,7 +165,7 @@ func TestMeasureManagementCommands(t *testing.T) {
 
 	// Re-add the measure and check
 	p.ExpectOK().Run("measure", "set", "test/projects/using-entities/measures.json")
-	p.ExpectJsonArray("qId", "measure-sum-numbers", "measure-count-numbers").Run("measure", "ls", "--json")
+	p.ExpectJsonArray("qId", "measure-count-numbers", "measure-sum-numbers").Run("measure", "ls", "--json")
 }
 
 func TestVariableManagementCommands(t *testing.T) {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -143,7 +143,7 @@ func TestDimensionManagementCommands(t *testing.T) {
 
 	// Re-add the measure and check
 	p.ExpectOK().Run("dimension", "set", "test/projects/using-entities/dimensions.json")
-	p.ExpectJsonArray("qId", "dimension-xyz", "dimension-abcs").Run("dimension", "ls", "--json")
+	p.ExpectJsonArray("qId", "dimension-abcs", "dimension-xyz").Run("dimension", "ls", "--json")
 }
 
 func TestMeasureManagementCommands(t *testing.T) {


### PR DESCRIPTION
Similar change that was earlier done for objects. Was not applied to `variables` due to running into problem with aborted requests. Since creating lots of variables through corectl seems like a less common scenario, I will leave it sequential for now.