### PR TITLE
chore: Update excluded commits from changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ changelog:
     exclude:
       - '^Update .+ commit hash to'
       - '^Update module .+ to'
-      - '^Automated: Bump Docker images$'
+      - '^Automated: Bump Docker images'
       - '^Release v\d\.\d\.\d(-\w+)?$'
 
 snapcrafts:


### PR DESCRIPTION
The automated image bumps are still present in the release changelog. Looks like the PR number is appended to the squash commit when merged to master.