### PR TITLE
Add log buffer

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,7 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/config.go
+++ b/internal/config.go
@@ -318,8 +318,6 @@ func getSuggestion(word string, validProps map[string]struct{}) string {
 }
 
 func mergeContext(config *map[interface{}]interface{}) {
-	// TODO: Create some sort of log buffer so verbose logs can be added
-	// before the config is complete.
 	contextHandler := NewContextHandler()
 	contextName := viper.GetString("context")
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -14,32 +14,6 @@ import (
 
 type logLevel int
 
-type logBuffer struct {
-	levels []logLevel
-	messages []string
-}
-
-func newBuffer() *logBuffer {
-	buf := &logBuffer{
-		levels: []logLevel{},
-		messages: []string{},
-	}
-	return buf
-}
-
-func (b *logBuffer) add(lvl logLevel, a ...interface{}) {
-	b.levels = append(b.levels, lvl)
-	b.messages = append(b.messages, fmt.Sprint(a...))
-}
-
-func (b *logBuffer) flush() {
-	for i, lvl := range b.levels {
-		print(lvl, b.messages[i])
-	}
-	b.levels = []logLevel{}
-	b.messages = []string{}
-}
-
 func (l logLevel) String() string {
 	switch l {
 	case quiet:
@@ -66,6 +40,37 @@ const (
 	info
 	verbose
 )
+
+type logBuffer struct {
+	levels []logLevel
+	messages []string
+}
+
+func newBuffer() *logBuffer {
+	buf := &logBuffer{
+		levels: []logLevel{},
+		messages: []string{},
+	}
+	return buf
+}
+
+func (b *logBuffer) add(lvl logLevel, a ...interface{}) {
+	b.levels = append(b.levels, lvl)
+	b.messages = append(b.messages, fmt.Sprint(a...))
+	// If it's fatal, we just want to dump everything in the buffer
+	if lvl == fatal {
+		buffering = false
+		b.flush()
+	}
+}
+
+func (b *logBuffer) flush() {
+	for i, lvl := range b.levels {
+		print(lvl, b.messages[i])
+	}
+	b.levels = []logLevel{}
+	b.messages = []string{}
+}
 
 var level logLevel
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -42,13 +42,13 @@ const (
 )
 
 type logBuffer struct {
-	levels []logLevel
+	levels   []logLevel
 	messages []string
 }
 
 func newBuffer() *logBuffer {
 	buf := &logBuffer{
-		levels: []logLevel{},
+		levels:   []logLevel{},
 		messages: []string{},
 	}
 	return buf

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -114,18 +114,12 @@ func TestQuietCommands(t *testing.T) {
 }
 
 func TestLogBuffer(t *testing.T) {
-	var out []byte
 	p := toolkit.Params{T: t, Config: "test/projects/quiet/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
 	p.ExpectOK().Run("context", "set", t.Name())
-	out = p.ExpectOK().Run("app", "ls", "-q")
-	if len(out) != 0 {
-		t.Errorf("Expected no output from 'corectl app ls -q' without apps, got:\n%s", string(out))
-	}
-	out = p.ExpectOK().Run("app", "ls")
-	t.Log(string(out))
-	if len(out) == 0 {
-		t.Error("Expected logged warning, but output was empty")
-	}
+	// The quiest flag should mute the warnings
+	p.ExpectEmptyOK().Run("app", "ls", "-q")
+	// We should have a warning saying something about context here
+	p.ExpectIncludes("context").Run("app", "ls")
 	p.ExpectOK().Run("context", "rm", t.Name())
 }
 

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -113,6 +113,22 @@ func TestQuietCommands(t *testing.T) {
 	}
 }
 
+func TestLogBuffer(t *testing.T) {
+	var out []byte
+	p := toolkit.Params{T: t, Config: "test/projects/quiet/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p.ExpectOK().Run("context", "set", t.Name())
+	out = p.ExpectOK().Run("app", "ls", "-q")
+	if len(out) != 0 {
+		t.Errorf("Expected no output from 'corectl app ls -q' without apps, got:\n%s", string(out))
+	}
+	out = p.ExpectOK().Run("app", "ls")
+	t.Log(string(out))
+	if len(out) == 0 {
+		t.Error("Expected logged warning, but output was empty")
+	}
+	p.ExpectOK().Run("context", "rm", t.Name())
+}
+
 func TestConnectionManagementCommands(t *testing.T) {
 	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()

--- a/test/projects/quiet/corectl.yml
+++ b/test/projects/quiet/corectl.yml
@@ -1,3 +1,4 @@
+engine: ${ENGINE_STD_URL}
 connections:
   data:
     connectionstring: /data


### PR DESCRIPTION
We can now properly log before the config has been read.
Logging rules will be obeyed with the exception of fatal errors occurring before the config has been completely read.


Closes #430 