### PR TITLE
Fatal if failing to set script

### DIFF
--- a/internal/script.go
+++ b/internal/script.go
@@ -16,4 +16,8 @@ func SetScript(ctx context.Context, doc *enigma.Doc, scriptFilePath string) {
 	}
 
 	err = doc.SetScript(ctx, string(loadScript))
+
+	if err != nil {
+		log.Fatalln("failed to set script: ", err)
+	}
 }


### PR DESCRIPTION
If failing to set a script we should log the error and exit, this was not handled earlier.

This closes #455