### PR TITLE
Rename engine flag to server

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -191,7 +191,7 @@ __extract_flags_to_forward()
 {
 	local forward_flags
 	local result
-	forward_flags=( "--engine" "-e" "--app" "-a" "--config" "-c" "--headers" "--ttl" );
+	forward_flags=( "--server" "-s" "--app" "-a" "--config" "-c" "--headers" "--ttl" );
 	while [[ $# -gt 0 ]]; do
 	  for i in "${forward_flags[@]}"
 	  do

--- a/docs/corectl.md
+++ b/docs/corectl.md
@@ -17,12 +17,12 @@ corectl [flags]
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_app.md
+++ b/docs/corectl_app.md
@@ -19,11 +19,11 @@ Explore and manage apps
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_app_import.md
+++ b/docs/corectl_app_import.md
@@ -30,11 +30,11 @@ corectl import <path-to-app.qvf>
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_app_ls.md
+++ b/docs/corectl_app_ls.md
@@ -30,11 +30,11 @@ corectl app ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_app_rm.md
+++ b/docs/corectl_app_rm.md
@@ -30,11 +30,11 @@ corectl app rm APP-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_assoc.md
+++ b/docs/corectl_assoc.md
@@ -30,11 +30,11 @@ corectl associations
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_bookmark.md
+++ b/docs/corectl_bookmark.md
@@ -19,11 +19,11 @@ Explore and manage bookmarks
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_bookmark_layout.md
+++ b/docs/corectl_bookmark_layout.md
@@ -29,11 +29,11 @@ corectl bBookmark layout BOOKMARK-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_bookmark_ls.md
+++ b/docs/corectl_bookmark_ls.md
@@ -29,11 +29,11 @@ corectl bookmark ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_bookmark_properties.md
+++ b/docs/corectl_bookmark_properties.md
@@ -30,11 +30,11 @@ corectl bookmark properties BOOKMARK-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_bookmark_rm.md
+++ b/docs/corectl_bookmark_rm.md
@@ -30,11 +30,11 @@ corectl dimension rm ID-1
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_build.md
+++ b/docs/corectl_build.md
@@ -42,11 +42,11 @@ corectl build --connections ./myconnections.yml --script ./myscript.qvs
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_catwalk.md
+++ b/docs/corectl_catwalk.md
@@ -31,11 +31,11 @@ corectl catwalk --app my-app.qvf --catwalk-url http://localhost:8080
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_completion.md
+++ b/docs/corectl_completion.md
@@ -37,11 +37,11 @@ corectl completion <shell> [flags]
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_connection.md
+++ b/docs/corectl_connection.md
@@ -19,11 +19,11 @@ Explore and manage connections
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_connection_get.md
+++ b/docs/corectl_connection_get.md
@@ -29,11 +29,11 @@ corectl connection get CONNECTION-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_connection_ls.md
+++ b/docs/corectl_connection_ls.md
@@ -30,11 +30,11 @@ corectl connection ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_connection_rm.md
+++ b/docs/corectl_connection_rm.md
@@ -31,11 +31,11 @@ corectl connection rm ID-1 ID-2
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_connection_set.md
+++ b/docs/corectl_connection_set.md
@@ -29,11 +29,11 @@ corectl connection set ./my-connections.yml
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context.md
+++ b/docs/corectl_context.md
@@ -6,7 +6,7 @@ Create, update and use contexts
 
 Create, update and use contexts
 
-Contexts store connection information such as engine url, certificates and headers,
+Contexts store connection information such as server url, certificates and headers,
 similar to a config. The main difference between contexts and configs is that they
 can be used globally. Use the context subcommands to configure contexts which
 facilitate app development in environments where certificates and headers are needed.
@@ -15,8 +15,8 @@ The current context is the one that is being used. You can use "context get" to
 display the contents of the current context and switch context with "context set"
 or unset the current context with "context unset".
 
-Note that contexts have the lowest precedence. This means that e.g. an --engine flag
-(or an engine field in a config) will override the engine url in the current context.
+Note that contexts have the lowest precedence. This means that e.g. an --server flag
+(or a server field in a config) will override the server url in the current context.
 
 Contexts are stored locally in your ~/.qlik/contexts.yml file.
 
@@ -33,11 +33,11 @@ Contexts are stored locally in your ~/.qlik/contexts.yml file.
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_clear.md
+++ b/docs/corectl_context_clear.md
@@ -29,11 +29,11 @@ corectl context clear
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_create.md
+++ b/docs/corectl_context_create.md
@@ -7,7 +7,7 @@ Create a context with the specified configuration
 Create a context with the specified configuration
 
 This command creates a context by using the supplied flags.
-The information stored will be engine url, headers and certificates
+The information stored will be server url, headers and certificates
 (if present) along with comment and the context-name.
 
 ```
@@ -18,7 +18,7 @@ corectl context create <context name> [flags]
 
 ```
 corectl context create local-engine
-corectl context create rd-sense --engine localhost:9076 --comment "R&D Qlik Sense deployment"
+corectl context create rd-sense --server localhost:9076 --comment "R&D Qlik Sense deployment"
 ```
 
 ### Options
@@ -35,11 +35,11 @@ corectl context create rd-sense --engine localhost:9076 --comment "R&D Qlik Sens
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_get.md
+++ b/docs/corectl_context_get.md
@@ -30,11 +30,11 @@ corectl context get local-engine
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_init.md
+++ b/docs/corectl_context_init.md
@@ -25,11 +25,11 @@ corectl context init <context name> [flags]
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_login.md
+++ b/docs/corectl_context_login.md
@@ -35,11 +35,11 @@ corectl context login context-name
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_ls.md
+++ b/docs/corectl_context_ls.md
@@ -29,11 +29,11 @@ corectl context ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_rm.md
+++ b/docs/corectl_context_rm.md
@@ -30,11 +30,11 @@ corectl context rm ctx1 ctx2
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_update.md
+++ b/docs/corectl_context_update.md
@@ -14,7 +14,7 @@ corectl context update <context name> [flags]
 
 ```
 corectl context update local-engine
-corectl context update rd-sense --engine localhost:9076 --comment "R&D Qlik Sense deployment"
+corectl context update rd-sense --server localhost:9076 --comment "R&D Qlik Sense deployment"
 ```
 
 ### Options
@@ -31,11 +31,11 @@ corectl context update rd-sense --engine localhost:9076 --comment "R&D Qlik Sens
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_context_use.md
+++ b/docs/corectl_context_use.md
@@ -29,11 +29,11 @@ corectl context use local-engine
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_dimension.md
+++ b/docs/corectl_dimension.md
@@ -19,11 +19,11 @@ Explore and manage dimensions
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_dimension_layout.md
+++ b/docs/corectl_dimension_layout.md
@@ -29,11 +29,11 @@ corectl dimension layout DIMENSION-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_dimension_ls.md
+++ b/docs/corectl_dimension_ls.md
@@ -30,11 +30,11 @@ corectl dimension ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_dimension_properties.md
+++ b/docs/corectl_dimension_properties.md
@@ -30,11 +30,11 @@ corectl dimension properties DIMENSION-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_dimension_rm.md
+++ b/docs/corectl_dimension_rm.md
@@ -30,11 +30,11 @@ corectl dimension rm ID-1
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_dimension_set.md
+++ b/docs/corectl_dimension_set.md
@@ -30,11 +30,11 @@ corectl dimension set ./my-dimensions-glob-path.json
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_eval.md
+++ b/docs/corectl_eval.md
@@ -32,11 +32,11 @@ corectl eval by "Region" // Returns the values for dimension "Region"
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_fields.md
+++ b/docs/corectl_fields.md
@@ -30,11 +30,11 @@ corectl fields
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_keys.md
+++ b/docs/corectl_keys.md
@@ -29,11 +29,11 @@ corectl keys
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_measure.md
+++ b/docs/corectl_measure.md
@@ -19,11 +19,11 @@ Explore and manage measures
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_measure_layout.md
+++ b/docs/corectl_measure_layout.md
@@ -29,11 +29,11 @@ corectl measure layout MEASURE-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_measure_ls.md
+++ b/docs/corectl_measure_ls.md
@@ -30,11 +30,11 @@ corectl measure ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_measure_properties.md
+++ b/docs/corectl_measure_properties.md
@@ -30,11 +30,11 @@ corectl measure properties MEASURE-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_measure_rm.md
+++ b/docs/corectl_measure_rm.md
@@ -30,11 +30,11 @@ corectl measure rm ID-1 ID-2
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_measure_set.md
+++ b/docs/corectl_measure_set.md
@@ -30,11 +30,11 @@ corectl measure set ./my-measures-glob-path.json
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_meta.md
+++ b/docs/corectl_meta.md
@@ -30,11 +30,11 @@ corectl meta --app my-app.qvf
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_object.md
+++ b/docs/corectl_object.md
@@ -19,11 +19,11 @@ Explore and manage generic objects
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_object_data.md
+++ b/docs/corectl_object_data.md
@@ -29,11 +29,11 @@ corectl object data OBJECT-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_object_layout.md
+++ b/docs/corectl_object_layout.md
@@ -29,11 +29,11 @@ corectl object layout OBJECT-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_object_ls.md
+++ b/docs/corectl_object_ls.md
@@ -30,11 +30,11 @@ corectl object ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_object_properties.md
+++ b/docs/corectl_object_properties.md
@@ -31,11 +31,11 @@ corectl object properties OBJECT-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_object_rm.md
+++ b/docs/corectl_object_rm.md
@@ -30,11 +30,11 @@ corectl object rm ID-1 ID-2
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_object_set.md
+++ b/docs/corectl_object_set.md
@@ -31,11 +31,11 @@ corectl object set ./my-objects-glob-path.json
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_reload.md
+++ b/docs/corectl_reload.md
@@ -32,11 +32,11 @@ corectl reload
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_script.md
+++ b/docs/corectl_script.md
@@ -19,11 +19,11 @@ Explore and manage the script
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_script_get.md
+++ b/docs/corectl_script_get.md
@@ -29,11 +29,11 @@ corectl script get
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_script_set.md
+++ b/docs/corectl_script_set.md
@@ -30,11 +30,11 @@ corectl script set ./my-script-file.qvs
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_state.md
+++ b/docs/corectl_state.md
@@ -19,11 +19,11 @@ Explore and manage alternate states
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_state_add.md
+++ b/docs/corectl_state_add.md
@@ -29,11 +29,11 @@ corectl state add NAME-1
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_state_ls.md
+++ b/docs/corectl_state_ls.md
@@ -30,11 +30,11 @@ corectl state ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_state_rm.md
+++ b/docs/corectl_state_rm.md
@@ -29,11 +29,11 @@ corectl state rm NAME-1
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_status.md
+++ b/docs/corectl_status.md
@@ -30,11 +30,11 @@ corectl status --app=my-app.qvf
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_tables.md
+++ b/docs/corectl_tables.md
@@ -30,11 +30,11 @@ corectl tables --app=my-app.qvf
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_unbuild.md
+++ b/docs/corectl_unbuild.md
@@ -35,11 +35,11 @@ corectl unbuild --app APP-ID
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_values.md
+++ b/docs/corectl_values.md
@@ -29,11 +29,11 @@ corectl values FIELD
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_variable.md
+++ b/docs/corectl_variable.md
@@ -19,11 +19,11 @@ Explore and manage variables
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_variable_layout.md
+++ b/docs/corectl_variable_layout.md
@@ -29,11 +29,11 @@ corectl variable layout VARIABLE-NAME
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_variable_ls.md
+++ b/docs/corectl_variable_ls.md
@@ -30,11 +30,11 @@ corectl variable ls
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_variable_properties.md
+++ b/docs/corectl_variable_properties.md
@@ -30,11 +30,11 @@ corectl variable properties VARIABLE-NAME
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_variable_rm.md
+++ b/docs/corectl_variable_rm.md
@@ -30,11 +30,11 @@ corectl variable rm NAME-1
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_variable_set.md
+++ b/docs/corectl_variable_set.md
@@ -30,11 +30,11 @@ corectl variable set ./my-variables-glob-path.json
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/corectl_version.md
+++ b/docs/corectl_version.md
@@ -29,11 +29,11 @@ corectl version
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "localhost:9076")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -27,11 +27,6 @@
     "context": {
       "description": "Name of the context used when connecting to Qlik Associative Engine"
     },
-    "engine": {
-      "alias": "e",
-      "description": "URL to the Qlik Associative Engine",
-      "default": "localhost:9076"
-    },
     "headers": {
       "description": "Http headers to use when connecting to Qlik Associative Engine",
       "default": "[]"
@@ -47,6 +42,10 @@
     "no-data": {
       "description": "Open app without data",
       "default": "false"
+    },
+    "server": {
+      "alias": "s",
+      "description": "URL to a Qlik Product, a local engine, cluster or sense-enterprise"
     },
     "traffic": {
       "alias": "t",
@@ -223,14 +222,14 @@
       }
     },
     "context": {
-      "description": "Create, update and use contexts\n\nContexts store connection information such as engine url, certificates and headers,\nsimilar to a config. The main difference between contexts and configs is that they\ncan be used globally. Use the context subcommands to configure contexts which\nfacilitate app development in environments where certificates and headers are needed.\n\nThe current context is the one that is being used. You can use \"context get\" to\ndisplay the contents of the current context and switch context with \"context set\"\nor unset the current context with \"context unset\".\n\nNote that contexts have the lowest precedence. This means that e.g. an --engine flag\n(or an engine field in a config) will override the engine url in the current context.\n\nContexts are stored locally in your ~/.qlik/contexts.yml file.",
+      "description": "Create, update and use contexts\n\nContexts store connection information such as server url, certificates and headers,\nsimilar to a config. The main difference between contexts and configs is that they\ncan be used globally. Use the context subcommands to configure contexts which\nfacilitate app development in environments where certificates and headers are needed.\n\nThe current context is the one that is being used. You can use \"context get\" to\ndisplay the contents of the current context and switch context with \"context set\"\nor unset the current context with \"context unset\".\n\nNote that contexts have the lowest precedence. This means that e.g. an --server flag\n(or a server field in a config) will override the server url in the current context.\n\nContexts are stored locally in your ~/.qlik/contexts.yml file.",
       "x-qlik-stability": "experimental",
       "commands": {
         "clear": {
           "description": "Set the current context to none"
         },
         "create": {
-          "description": "Create a context with the specified configuration\n\nThis command creates a context by using the supplied flags.\nThe information stored will be engine url, headers and certificates\n(if present) along with comment and the context-name.",
+          "description": "Create a context with the specified configuration\n\nThis command creates a context by using the supplied flags.\nThe information stored will be server url, headers and certificates\n(if present) along with comment and the context-name.",
           "flags": {
             "comment": {
               "description": "Comment for the context"

--- a/examples/corectl.yml
+++ b/examples/corectl.yml
@@ -1,4 +1,4 @@
-engine: localhost:9076 # URL and port to running Qlik Associative Engine instance
+server: localhost:9076 # URL and port to running Qlik Associative Engine instance
 app: corectl-example.qvf # App name that the tool should open a session against.
 script: ./script.qvs # Path to a script that should be set in the app
 connections: # Connections that should be created in the app

--- a/pkg/boot/common_settings.go
+++ b/pkg/boot/common_settings.go
@@ -70,19 +70,19 @@ func (c *CommonSettings) Headers() http.Header {
 	return headers
 }
 
-func (c *CommonSettings) Engine() string {
-	return c.GetString("engine")
+func (c *CommonSettings) Server() string {
+	return c.GetString("server")
 }
 
-// engineURL returns the parsed engine url
-func (c *CommonSettings) engineURL() *neturl.URL {
-	engine := c.Engine()
-	if engine == "" {
-		log.Fatalln("engine URL not specified")
+// serverURL returns the parsed engine url
+func (c *CommonSettings) serverURL() *neturl.URL {
+	server := c.Server()
+	if server == "" {
+		log.Fatalln("server URL not specified")
 	}
-	u, err := parseURL(engine, "ws")
+	u, err := parseURL(server, "ws")
 	if err != nil {
-		log.Fatalf("could not parse engine url '%s' got error: '%s'\n", engine, err)
+		log.Fatalf("could not parse server url '%s' got error: '%s'\n", server, err)
 	}
 	return u
 }
@@ -92,7 +92,7 @@ func (c *CommonSettings) engineURL() *neturl.URL {
 ////////////////////////////////////////
 
 func (c *CommonSettings) IsSenseForKubernetes() bool {
-	if c.engineURL().Scheme == "http" || c.engineURL().Scheme == "https" {
+	if c.serverURL().Scheme == "http" || c.serverURL().Scheme == "https" {
 		return true
 	} else {
 		return false
@@ -100,7 +100,7 @@ func (c *CommonSettings) IsSenseForKubernetes() bool {
 }
 
 func (c *CommonSettings) RestBaseUrl() *neturl.URL {
-	u, _ := neturl.Parse(c.engineURL().String()) //Clone it since we are going to modify it
+	u, _ := neturl.Parse(c.serverURL().String()) //Clone it since we are going to modify it
 	// CreateBaseURL returns the base URL for Rest API calls based on the value of 'engine'
 	if u.Scheme == "ws" {
 		u.Scheme = "http"
@@ -125,7 +125,7 @@ func (c *CommonSettings) RestAdaptedAppId() string {
 /////////////////////////////////////////////
 
 func (c *CommonSettings) WebSocketEngineURL() string {
-	engineUrl := c.engineURL()
+	engineUrl := c.serverURL()
 	if c.IsSenseForKubernetes() {
 		if engineUrl.Scheme == "https" {
 			return "wss://" + engineUrl.Host + "/app/" + c.AppId()
@@ -143,14 +143,14 @@ func (c *CommonSettings) WebSocketEngineURL() string {
 }
 
 func (c *CommonSettings) AppIdMappingNamespace() string {
-	engineURL := c.engineURL()
-	return engineURL.Host
+	serverURL := c.serverURL()
+	return serverURL.Host
 }
 
 func (c *CommonSettings) App() string {
 	appName := c.GetString("app")
 	if appName == "" {
-		appName = tryParseAppFromURL(c.GetString("engine"))
+		appName = tryParseAppFromURL(c.GetString("server"))
 	}
 	return appName
 }

--- a/pkg/boot/flags.go
+++ b/pkg/boot/flags.go
@@ -11,7 +11,7 @@ func InjectGlobalFlags(command *cobra.Command, hideEngineSpecificFlags bool) {
 	globalFlags := command.PersistentFlags()
 	globalFlags.BoolP("verbose", "v", false, "Log extra information")
 	globalFlags.BoolP("traffic", "t", false, "Log JSON websocket traffic to stdout")
-	globalFlags.StringP("engine", "e", "localhost:9076", "URL to the Qlik Associative Engine")
+	globalFlags.StringP("server", "s", "", "URL to a Qlik Product, a local engine, cluster or sense-enterprise")
 	globalFlags.StringP("app", "a", "", "Name or identifier of the app")
 	globalFlags.String("ttl", "0", "Qlik Associative Engine session time to live in seconds")
 	globalFlags.Bool("json", false, "Returns output in JSON format if possible, disables verbose and traffic output")
@@ -28,7 +28,7 @@ func InjectGlobalFlags(command *cobra.Command, hideEngineSpecificFlags bool) {
 
 	// Set annotation to run bash completion function
 	globalFlags.SetAnnotation("app", cobra.BashCompCustom, []string{"__corectl_get_apps"})
-	globalFlags.SetAnnotation("engine", cobra.BashCompCustom, []string{"__corectl_get_local_engines"})
+	globalFlags.SetAnnotation("server", cobra.BashCompCustom, []string{"__corectl_get_local_engines"})
 	globalFlags.SetAnnotation("context", cobra.BashCompCustom, []string{"__corectl_get_contexts"})
 
 	if runtime.GOOS != "windows" {

--- a/pkg/boot/qixsocket.go
+++ b/pkg/boot/qixsocket.go
@@ -22,7 +22,7 @@ type EngineWebSocketSettings interface {
 	Insecure() bool
 	Headers() http.Header
 
-	Engine() string
+	Server() string
 	App() string
 	AppId() string
 	Ttl() string

--- a/pkg/commands/login/init.go
+++ b/pkg/commands/login/init.go
@@ -103,7 +103,7 @@ func setupContext(tenant, apikey, explicitContextName string) {
 	contextName := contextName(explicitContextName, tenantUrl)
 
 	contextHandler.Contexts[contextName] = dynconf.Context{
-		"engine":  tenantUrl,
+		"server":  tenantUrl,
 		"headers": map[string]string{"Authorization": "Bearer " + apikey},
 	}
 	contextHandler.Current = contextName

--- a/pkg/commands/standard/context.go
+++ b/pkg/commands/standard/context.go
@@ -17,11 +17,11 @@ func CreateContextCommand() *cobra.Command {
 		Long: `Create a context with the specified configuration
 
 This command creates a context by using the supplied flags.
-The information stored will be engine url, headers and certificates
+The information stored will be server url, headers and certificates
 (if present) along with comment and the context-name.`,
 
 		Example: `corectl context create local-engine
-corectl context create rd-sense --engine localhost:9076 --comment "R&D Qlik Sense deployment"`,
+corectl context create rd-sense --server localhost:9076 --comment "R&D Qlik Sense deployment"`,
 
 		Run: func(ccmd *cobra.Command, args []string) {
 
@@ -44,8 +44,8 @@ corectl context create rd-sense --engine localhost:9076 --comment "R&D Qlik Sens
 				cfg.GetTLSConfigFromPath("certificates")
 			}
 
-			if !cfg.IsUsingDefaultValue("engine") {
-				newSettings["engine"] = cfg.GetString("engine")
+			if !cfg.IsUsingDefaultValue("server") {
+				newSettings["server"] = cfg.GetString("server")
 			}
 
 			dynconf.CreateContext(args[0], newSettings)
@@ -59,7 +59,7 @@ corectl context create rd-sense --engine localhost:9076 --comment "R&D Qlik Sens
 		Long:  "Update a context with the specified configuration",
 
 		Example: `corectl context update local-engine
-corectl context update rd-sense --engine localhost:9076 --comment "R&D Qlik Sense deployment"`,
+corectl context update rd-sense --server localhost:9076 --comment "R&D Qlik Sense deployment"`,
 
 		Run: func(ccmd *cobra.Command, args []string) {
 
@@ -82,8 +82,8 @@ corectl context update rd-sense --engine localhost:9076 --comment "R&D Qlik Sens
 				cfg.GetTLSConfigFromPath("certificates")
 			}
 
-			if !cfg.IsUsingDefaultValue("engine") {
-				newSettings["engine"] = cfg.GetString("engine")
+			if !cfg.IsUsingDefaultValue("server") {
+				newSettings["server"] = cfg.GetString("server")
 			}
 
 			dynconf.UpdateContext(args[0], newSettings)
@@ -202,7 +202,7 @@ corectl context login context-name`,
 		Short: "Create, update and use contexts",
 		Long: `Create, update and use contexts
 
-Contexts store connection information such as engine url, certificates and headers,
+Contexts store connection information such as server url, certificates and headers,
 similar to a config. The main difference between contexts and configs is that they
 can be used globally. Use the context subcommands to configure contexts which
 facilitate app development in environments where certificates and headers are needed.
@@ -211,8 +211,8 @@ The current context is the one that is being used. You can use "context get" to
 display the contents of the current context and switch context with "context set"
 or unset the current context with "context unset".
 
-Note that contexts have the lowest precedence. This means that e.g. an --engine flag
-(or an engine field in a config) will override the engine url in the current context.
+Note that contexts have the lowest precedence. This means that e.g. an --server flag
+(or a server field in a config) will override the server url in the current context.
 
 Contexts are stored locally in your ~/` + dynconf.ContextDir + `/contexts.yml file.`,
 		Annotations: map[string]string{

--- a/printer/contexts.go
+++ b/printer/contexts.go
@@ -26,7 +26,7 @@ func PrintContext(name string, handler *dynconf.ContextHandler) {
 	}
 	fmt.Printf("Name: %s\n", name)
 	fmt.Printf("Comment: %s\n", context.GetString("comment"))
-	fmt.Printf("Engine: %s\n", context.GetString("engine"))
+	fmt.Printf("Server: %s\n", context.GetString("server"))
 	fmt.Printf("Certificates: %s\n", context.GetString("certificates"))
 	fmt.Println("Headers:")
 	for k, v := range context.Headers() {
@@ -60,12 +60,12 @@ func PrintContexts(handler *dynconf.ContextHandler, mode log.PrintMode) {
 		writer := tablewriter.NewWriter(os.Stdout)
 		writer.SetAutoFormatHeaders(false)
 		writer.SetRowLine(true)
-		header := []string{"Name", "Engine", "Current", "Comment"}
+		header := []string{"Name", "Server", "Current", "Comment"}
 		writer.SetHeader(header)
 
 		for _, k := range sortedContextKeys {
 			context := handler.Get(k)
-			row := []string{k, context.GetString("engine"), "", context.GetString("comment")}
+			row := []string{k, context.GetString("server"), "", context.GetString("comment")}
 			if k == handler.Current {
 				// In case we change header order
 				for i, h := range header {

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -15,7 +15,7 @@ import (
 func TestBasicAnalyzing(t *testing.T) {
 
 	os.Setenv("CONN_TYPE", "folder")
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 
 	p.ExpectOK().Run("build")
@@ -39,7 +39,7 @@ func TestBasicAnalyzing(t *testing.T) {
 }
 
 func TestReload(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 	p.ExpectIncludes("<<  5 Lines fetched").Run("build")
 	p.ExpectIncludes("<<  3 Lines fetched").Run("build", "--limit", "3")
@@ -50,8 +50,8 @@ func TestReload(t *testing.T) {
 
 func TestContextManagement(t *testing.T) {
 	flags := [][]string{
-		{"--engine", *toolkit.EngineJwtIP, "--config", "test/projects/using-jwts/corectl.yml"},
-		{"--engine", *toolkit.EngineAbacIP, "--config", "test/projects/abac/corectl.yml"},
+		{"--server", *toolkit.EngineJwtIP, "--config", "test/projects/using-jwts/corectl.yml"},
+		{"--server", *toolkit.EngineAbacIP, "--config", "test/projects/abac/corectl.yml"},
 	}
 	contexts := []string{t.Name() + "_JWT", t.Name() + "_ABAC"}
 	// Empty params, should default to localhost:9076 when there is no context
@@ -70,11 +70,11 @@ func TestContextManagement(t *testing.T) {
 	// Current context should be abac, connecting to jwt shouldn't work
 	p.ExpectIncludes(contexts[1]).Run("context", "get")
 
-	p.ExpectError().Run("status", "--engine", *toolkit.EngineJwtIP)
+	p.ExpectError().Run("status", "--server", *toolkit.EngineJwtIP)
 	// Check if we can update contexts
-	p.ExpectOK().Run("context", "update", contexts[1], "--engine", *toolkit.EngineStdIP)
+	p.ExpectOK().Run("context", "update", contexts[1], "--server", *toolkit.EngineStdIP)
 	p.ExpectIncludes(*toolkit.EngineStdIP).Run("status")
-	p.ExpectOK().Run("context", "update", contexts[1], "--engine", *toolkit.EngineAbacIP)
+	p.ExpectOK().Run("context", "update", contexts[1], "--server", *toolkit.EngineAbacIP)
 	p.ExpectIncludes(*toolkit.EngineAbacIP).Run("context", "get")
 	// See if all context commands work
 	for i, ctx := range contexts {
@@ -88,11 +88,11 @@ func TestContextManagement(t *testing.T) {
 		p.ExpectOK().Run("context", "rm", ctx)
 	}
 	// No context here, expecting default
-	p.ExpectIncludes("localhost:9076").Run("status")
+	p.ExpectIncludes("URL not specified").Run("status")
 }
 
 func TestQuietCommands(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/quiet/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/quiet/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	cmds := []string{
 		"connection", "dimension", "measure",
 		"object", "state", "variable",
@@ -118,7 +118,7 @@ func TestQuietCommands(t *testing.T) {
 }
 
 func TestLogBuffer(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/quiet/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/quiet/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	p.ExpectOK().Run("context", "create", t.Name())
 	p.ExpectOK().Run("context", "use", t.Name())
 	// The quiest flag should mute the warnings
@@ -129,7 +129,7 @@ func TestLogBuffer(t *testing.T) {
 }
 
 func TestConnectionManagementCommands(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 	p.Run("build")
 	p.ExpectIncludes(`myconnection | testconnector`).Run("connection", "ls")
@@ -137,7 +137,7 @@ func TestConnectionManagementCommands(t *testing.T) {
 }
 
 func TestObjectManagementCommands(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 
 	// Build with both objects and check
@@ -165,7 +165,7 @@ func TestObjectManagementCommands(t *testing.T) {
 }
 
 func TestDimensionManagementCommands(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 
 	// Build with both dimensions and check
@@ -187,7 +187,7 @@ func TestDimensionManagementCommands(t *testing.T) {
 }
 
 func TestMeasureManagementCommands(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 
 	// Build with both measures and check
@@ -209,7 +209,7 @@ func TestMeasureManagementCommands(t *testing.T) {
 }
 
 func TestVariableManagementCommands(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 
 	// Build with both variables and check
@@ -231,7 +231,7 @@ func TestVariableManagementCommands(t *testing.T) {
 }
 
 func TestBookmarkManagementCommands(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 
 	// Build with two bookmarks
@@ -254,7 +254,7 @@ func TestBookmarkManagementCommands(t *testing.T) {
 }
 
 func TestOpeningWithoutData(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, Config: "test/projects/using-entities/corectl.yml", App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, Config: "test/projects/using-entities/corectl.yml", App: t.Name()}
 	defer p.Reset()
 
 	p.ExpectOK().Run("build")
@@ -267,7 +267,7 @@ func TestOpeningWithoutData(t *testing.T) {
 }
 
 func TestScriptManagementCommands(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name(), Ttl: "0"}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name(), Ttl: "0"}
 	defer p.Reset()
 
 	p.ExpectOK().Run("build", "--script", "test/projects/using-script/script1.qvs")
@@ -282,7 +282,7 @@ func TestScriptManagementCommands(t *testing.T) {
 }
 
 func TestScriptVariables(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 	// Build with script that creates two variables and check
 	p.ExpectOK().Run("build", "--script", "test/projects/using-script/script3.qvs")
@@ -290,7 +290,7 @@ func TestScriptVariables(t *testing.T) {
 }
 
 func TestTrafficFlag(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name(), Ttl: "0"}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name(), Ttl: "0"}
 	defer p.Reset()
 
 	p.ExpectOK().Run("build")
@@ -300,10 +300,10 @@ func TestTrafficFlag(t *testing.T) {
 
 func TestUsingJwt(t *testing.T) {
 	p := toolkit.Params{T: t, Ttl: "0"}
-	p1 := p.WithParams(toolkit.Params{Engine: *toolkit.EngineStdIP})
-	p2 := p.WithParams(toolkit.Params{Engine: *toolkit.EngineJwtIP})
-	p3 := p.WithParams(toolkit.Params{Engine: *toolkit.EngineJwtIP, Headers: `authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0`})
-	p4 := p.WithParams(toolkit.Params{Engine: *toolkit.EngineJwtIP, Config: "test/projects/using-jwts/corectl.yml"})
+	p1 := p.WithParams(toolkit.Params{Server: *toolkit.EngineStdIP})
+	p2 := p.WithParams(toolkit.Params{Server: *toolkit.EngineJwtIP})
+	p3 := p.WithParams(toolkit.Params{Server: *toolkit.EngineJwtIP, Headers: `authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb2xrZSJ9.MD_revuZ8lCEa6bb-qtfYaHdxBiRMUkuH86c4kd1yC0`})
+	p4 := p.WithParams(toolkit.Params{Server: *toolkit.EngineJwtIP, Config: "test/projects/using-jwts/corectl.yml"})
 
 	p1.ExpectOK().ExpectIncludes("Connected without app to").Run("status")
 	p2.ExpectErrorIncludes("headers", "authorization").Run("status")
@@ -312,24 +312,24 @@ func TestUsingJwt(t *testing.T) {
 }
 
 func TestHelp(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP}
 	p.ExpectGolden().Run("")
 	p.ExpectGolden().Run("help")
 	p.ExpectGolden().Run("help", "build")
 }
 
 func TestAppMissing(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP}
 	p.ExpectErrorIncludes("no app specified").Run("connection", "ls")
 }
 
 func TestCatwalkUrl(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP}
 	p.ExpectIncludes("Please provide a valid URL starting with 'https://', 'http://' or 'www'").Run("catwalk", "--catwalk-url=not-a-valid-url")
 }
 
 func TestWithoutApp(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP}
 
 	p.ExpectOK().Run("status")
 	p.ExpectOK().Run("version")
@@ -354,7 +354,7 @@ func TestWithoutApp(t *testing.T) {
 }
 
 func TestWithUnknownApp(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name()}
 	p.ExpectError().Run("reload")
 
 	p.ExpectErrorIncludes("Could not find app").Run("assoc")
@@ -373,23 +373,23 @@ func TestWithUnknownApp(t *testing.T) {
 }
 
 func TestEvalOnUnknownAppl(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name()}
 	p.ExpectIncludes("Could not find app: App not found (1003").Run("eval", "count(numbers)", "by", "xyz")
 }
 
 func TestEvalOnUnknownAppEngine(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: "localhost:9999", App: t.Name()}
+	p := toolkit.Params{T: t, Server: "localhost:9999", App: t.Name()}
 	p.ExpectErrorIncludes("engine", "url").Run("eval", "count(numbers)", "by", "xyz")
 }
 
 // Disabled due to change in behaviour when configuring incorrect license
 func DisabledTestLicenseServiceDown(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineBadLicenseServerIP, App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineBadLicenseServerIP, App: t.Name()}
 	p.ExpectIncludes("SESSION_ERROR_NO_LICENSE").Run("app", "ls")
 }
 
 func TestAppsInABAC(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineAbacIP, Config: "test/projects/abac/corectl.yml", App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineAbacIP, Config: "test/projects/abac/corectl.yml", App: t.Name()}
 	defer p.Reset()
 	p.ExpectGolden().Run("build")
 	p.ExpectIncludes("Connected to", "The data model has 1 table.").Run("status")
@@ -399,10 +399,10 @@ func TestAppsInABAC(t *testing.T) {
 }
 
 func TestInvalidConfigs(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name()}
 	pi1 := p.WithParams(toolkit.Params{Config: "test/projects/invalid-config/corectl-invalid.yml"})
 	pi2 := p.WithParams(toolkit.Params{Config: "test/projects/invalid-config/corectl-invalid2.yml"})
-	pi1.ExpectIncludes("'engin': did you mean 'engine'?",
+	pi1.ExpectIncludes("'serve': did you mean 'server'?",
 		"'dimension': did you mean 'dimensions'?",
 		"'verbos': did you mean 'verbose'?",
 		"'apps': did you mean 'app'?",
@@ -417,7 +417,7 @@ func TestInvalidConfigs(t *testing.T) {
 }
 
 func TestChildObjectsAndFullPropertyTree(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, Ttl: "0", App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, Ttl: "0", App: t.Name()}
 	defer p.Reset()
 
 	// Build the app with an object with two children
@@ -435,7 +435,7 @@ func TestChildObjectsAndFullPropertyTree(t *testing.T) {
 }
 
 func TestGetFullPropertyTree(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, Ttl: "0", App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, Ttl: "0", App: t.Name()}
 	defer p.Reset()
 
 	// Build the app with an object with two children
@@ -446,7 +446,7 @@ func TestGetFullPropertyTree(t *testing.T) {
 }
 
 func TestGetFullPropertyTreeMinimum(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, Ttl: "0", App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, Ttl: "0", App: t.Name()}
 	defer p.Reset()
 
 	// Build the app with an object with two children
@@ -459,11 +459,11 @@ func TestGetFullPropertyTreeMinimum(t *testing.T) {
 func TestConnectionDefinitionVariations(t *testing.T) {
 
 	os.Setenv("CONN_TYPE", "folder")
-	pNoConnections := toolkit.Params{T: t, Config: "test/projects/connections/corectl-no-connections.yml", Engine: *toolkit.EngineStdIP, App: t.Name() + "-1"}
-	pCommandLine := toolkit.Params{T: t, Config: "test/projects/connections/corectl-no-connections.yml", Engine: *toolkit.EngineStdIP, App: t.Name() + "-2"}
-	pWithConnections := toolkit.Params{T: t, Config: "test/projects/connections/corectl-with-connections.yml", Engine: *toolkit.EngineStdIP, App: t.Name() + "-3"}
-	pConnectionsFile := toolkit.Params{T: t, Config: "test/projects/connections/corectl-connectionsref.yml", Engine: *toolkit.EngineStdIP, App: t.Name() + "-4"}
-	pConnectionsFileEmpty := toolkit.Params{T: t, Config: "test/projects/connections/corectl-connectionsref-empty.yml", Engine: *toolkit.EngineStdIP, App: t.Name() + "-5"}
+	pNoConnections := toolkit.Params{T: t, Config: "test/projects/connections/corectl-no-connections.yml", Server: *toolkit.EngineStdIP, App: t.Name() + "-1"}
+	pCommandLine := toolkit.Params{T: t, Config: "test/projects/connections/corectl-no-connections.yml", Server: *toolkit.EngineStdIP, App: t.Name() + "-2"}
+	pWithConnections := toolkit.Params{T: t, Config: "test/projects/connections/corectl-with-connections.yml", Server: *toolkit.EngineStdIP, App: t.Name() + "-3"}
+	pConnectionsFile := toolkit.Params{T: t, Config: "test/projects/connections/corectl-connectionsref.yml", Server: *toolkit.EngineStdIP, App: t.Name() + "-4"}
+	pConnectionsFileEmpty := toolkit.Params{T: t, Config: "test/projects/connections/corectl-connectionsref-empty.yml", Server: *toolkit.EngineStdIP, App: t.Name() + "-5"}
 	defer pNoConnections.Reset() //This resets all apps since last reset
 
 	//Build the apps
@@ -481,7 +481,7 @@ func TestConnectionDefinitionVariations(t *testing.T) {
 
 // TestPrecedence checks that command line flags overrides config props
 func TestCommandLineOverridingConfigFile(t *testing.T) {
-	p := toolkit.Params{T: t, Config: "test/projects/presedence/corectl.yml", Engine: *toolkit.EngineStdIP}
+	p := toolkit.Params{T: t, Config: "test/projects/presedence/corectl.yml", Server: *toolkit.EngineStdIP}
 	defer p.Reset()
 	p1 := p.WithParams(toolkit.Params{App: t.Name() + "-1"})
 	p2 := p.WithParams(toolkit.Params{App: t.Name() + "-2"})
@@ -507,9 +507,9 @@ func TestCommandLineOverridingConfigFile(t *testing.T) {
 
 func TestImportApp(t *testing.T) {
 	// Create tests for the standard, abac and jwt case.
-	pStd := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP}
-	pAbac := toolkit.Params{T: t, Engine: *toolkit.EngineAbacIP}
-	pJwt := toolkit.Params{T: t, Engine: *toolkit.EngineJwtIP, Config: "test/projects/using-jwts/corectl.yml"}
+	pStd := toolkit.Params{T: t, Server: *toolkit.EngineStdIP}
+	pAbac := toolkit.Params{T: t, Server: *toolkit.EngineAbacIP}
+	pJwt := toolkit.Params{T: t, Server: *toolkit.EngineJwtIP, Config: "test/projects/using-jwts/corectl.yml"}
 	params := []toolkit.Params{pStd, pAbac, pJwt}
 	for _, p := range params {
 		// See if we can import the app test.qvf
@@ -522,8 +522,8 @@ func TestImportApp(t *testing.T) {
 
 func TestUnbuild(t *testing.T) {
 	os.Setenv("CONN_TYPE", "folder")
-	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name()}
-	p2 := toolkit.Params{T: t, Config: "test/golden/unbuild/corectl.yml", Engine: *toolkit.EngineStdIP, App: t.Name() + "-rebuild"}
+	p := toolkit.Params{T: t, Config: "test/projects/using-entities/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name()}
+	p2 := toolkit.Params{T: t, Config: "test/golden/unbuild/corectl.yml", Server: *toolkit.EngineStdIP, App: t.Name() + "-rebuild"}
 	defer p.Reset()
 
 	p.ExpectOK().Run("build")
@@ -538,7 +538,7 @@ func TestUnbuild(t *testing.T) {
 }
 
 func TestAddState(t *testing.T) {
-	p := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name()}
+	p := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name()}
 	defer p.Reset()
 	p.ExpectOK().Run("build")
 	p.ExpectIncludes("Saving app...", "success").Run("state", "add", "MyTestState")
@@ -549,8 +549,8 @@ func TestAddState(t *testing.T) {
 
 func TestCertificatesPath(t *testing.T) {
 	relativePath := "test/projects/certificates/"
-	pFlag := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name(), Certificates: relativePath}
-	pConfig := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name(), Config: relativePath + "corectl-certificates.yml"}
+	pFlag := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name(), Certificates: relativePath}
+	pConfig := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name(), Config: relativePath + "corectl-certificates.yml"}
 	absolutePath, _ := filepath.Abs(relativePath)
 	contextName := "cert-test"
 
@@ -572,9 +572,9 @@ func TestCertificatesPath(t *testing.T) {
 }
 
 func TestCertificatesPathNegative(t *testing.T) {
-	pFlagNoCerts := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name(), Certificates: "test/projects/"}
-	pConfigNoCerts := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name(), Config: "test/projects/certificates/corectl-certificates-invalid-path.yml"}
-	pInvalidPath := toolkit.Params{T: t, Engine: *toolkit.EngineStdIP, App: t.Name(), Certificates: "test/projects/non-existing-folder"}
+	pFlagNoCerts := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name(), Certificates: "test/projects/"}
+	pConfigNoCerts := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name(), Config: "test/projects/certificates/corectl-certificates-invalid-path.yml"}
+	pInvalidPath := toolkit.Params{T: t, Server: *toolkit.EngineStdIP, App: t.Name(), Certificates: "test/projects/non-existing-folder"}
 
 	params := []toolkit.Params{pFlagNoCerts, pConfigNoCerts, pInvalidPath}
 	for _, p := range params {

--- a/test/golden/TestHelp_#00.golden
+++ b/test/golden/TestHelp_#00.golden
@@ -42,12 +42,12 @@ Flags:
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/test/golden/TestHelp_help.golden
+++ b/test/golden/TestHelp_help.golden
@@ -42,12 +42,12 @@ Flags:
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
   -h, --help                     help for corectl
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/test/golden/TestHelp_help_build.golden
+++ b/test/golden/TestHelp_help_build.golden
@@ -27,11 +27,11 @@ Global Flags:
       --certificates string      path/to/folder containing client.pem, client_key.pem and root.pem certificates
   -c, --config string            path/to/config.yml where parameters can be set instead of on the command line
       --context string           Name of the context used when connecting to Qlik Associative Engine
-  -e, --engine string            URL to the Qlik Associative Engine (default "<host>:<port>")
       --headers stringToString   Http headers to use when connecting to Qlik Associative Engine (default [])
       --insecure                 Enabling insecure will make it possible to connect using self signed certificates
       --json                     Returns output in JSON format if possible, disables verbose and traffic output
       --no-data                  Open app without data
+  -s, --server string            URL to a Qlik Product, a local engine, cluster or sense-enterprise
   -t, --traffic                  Log JSON websocket traffic to stdout
       --ttl string               Qlik Associative Engine session time to live in seconds (default "0")
   -v, --verbose                  Log extra information

--- a/test/projects/abac/corectl.yml
+++ b/test/projects/abac/corectl.yml
@@ -1,4 +1,4 @@
-engine: localhost:9276
+server: localhost:9276
 app: corectl_test_app.qvf
 script: ./script.qvs
 connections:

--- a/test/projects/connections/corectl-connectionsref-empty.yml
+++ b/test/projects/connections/corectl-connectionsref-empty.yml
@@ -1,2 +1,2 @@
-engine: ${ENGINE_STD_URL}
+server: ${ENGINE_STD_URL}
 connections: ./connections-empty.yml

--- a/test/projects/connections/corectl-connectionsref.yml
+++ b/test/projects/connections/corectl-connectionsref.yml
@@ -1,2 +1,2 @@
-engine: ${ENGINE_STD_URL}
+server: ${ENGINE_STD_URL}
 connections: ./connections.yml

--- a/test/projects/connections/corectl-no-connections.yml
+++ b/test/projects/connections/corectl-no-connections.yml
@@ -1,1 +1,1 @@
-engine: ${ENGINE_STD_URL}
+server: ${ENGINE_STD_URL}

--- a/test/projects/connections/corectl-with-connections.yml
+++ b/test/projects/connections/corectl-with-connections.yml
@@ -1,4 +1,4 @@
-engine: ${ENGINE_STD_URL}
+server: ${ENGINE_STD_URL}
 connections:
   testdata-inline:
     connectionstring: /data

--- a/test/projects/invalid-config/corectl-invalid.yml
+++ b/test/projects/invalid-config/corectl-invalid.yml
@@ -1,4 +1,4 @@
-engin: localhost:9076
+serve: localhost:9076
 scrip: ./script.qvs
 apps: corectl_test_app.qvf
 connection: 

--- a/test/projects/invalid-config/corectl-invalid2.yml
+++ b/test/projects/invalid-config/corectl-invalid2.yml
@@ -1,4 +1,4 @@
-engine: localhost:9076
+server: localhost:9076
 script: ./script.qvs
 connections:
   testdata:

--- a/test/projects/presedence/corectl.yml
+++ b/test/projects/presedence/corectl.yml
@@ -1,4 +1,4 @@
-engine: ${ENGINE_STD_URL}
+server: ${ENGINE_STD_URL}
 connections:
   testdata:
     connectionstring: /data

--- a/test/projects/quiet/corectl.yml
+++ b/test/projects/quiet/corectl.yml
@@ -1,4 +1,4 @@
-engine: ${ENGINE_STD_URL}
+server: ${ENGINE_STD_URL}
 connections:
   data:
     connectionstring: /data

--- a/test/projects/using-entities/corectl.yml
+++ b/test/projects/using-entities/corectl.yml
@@ -1,4 +1,4 @@
-engine: ${ENGINE_STD_URL}
+server: ${ENGINE_STD_URL}
 script: ./script.qvs
 app-properties: app-properties.json
 connections:

--- a/test/toolkit/test_toolkit.go
+++ b/test/toolkit/test_toolkit.go
@@ -20,7 +20,7 @@ type Params struct {
 	T            *testing.T
 	App          string
 	Config       string
-	Engine       string
+	Server       string
 	Headers      string
 	NoData       string
 	Traffic      string
@@ -145,8 +145,8 @@ func (p *Params) WithParams(newP Params) Params {
 	if newP.Config != "" {
 		pc.Config = newP.Config
 	}
-	if newP.Engine != "" {
-		pc.Engine = newP.Engine
+	if newP.Server != "" {
+		pc.Server = newP.Server
 	}
 	if newP.App != "" {
 		pc.App = newP.App
@@ -177,8 +177,8 @@ func (p *Params) Run(command ...string) []byte {
 		if p.App != "" {
 			args = append(args, "--app", p.App)
 		}
-		if p.Engine != "" {
-			args = append(args, "--engine", p.Engine)
+		if p.Server != "" {
+			args = append(args, "--server", p.Server)
 		}
 		if p.Config != "" {
 			args = append(args, "--config", p.Config)


### PR DESCRIPTION
This will change the name of the `--engine` flag to `--server` which is breaking in a major way. Therefore, it should only be included in a 2.0 release, of course.

I think I found the cases where it is used but surely some cases where it is mentioned in documentation is missed.

Furthermore, we should probably think about a strategy for making these changes a bit more backwards compatible, at least for the 2.0 release.