### PR TITLE
Expose separate Boot function

### DIFF
--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -11,10 +11,17 @@ import (
 )
 
 func NewCommunicator(ccmd *cobra.Command) *Communicator {
+	commonSettings := Boot(ccmd)
+	return &Communicator{CommonSettings: commonSettings}
+}
+
+// Boot reads all the configuration for a command and sets
+// the log verbosity for the logger.
+func Boot(ccmd *cobra.Command) *CommonSettings {
 	cfg := dynconf.ReadSettings(ccmd)
 	commonSettings := NewCommonSettings(cfg)
 	log.Init(commonSettings.PrintMode())
-	return &Communicator{CommonSettings: commonSettings}
+	return commonSettings
 }
 
 type Communicator struct {


### PR DESCRIPTION
Exposing a boot function that can be used in the case you want to read settings but don't need a communicator.