### PR TITLE
Make user-agent more precise

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,12 @@ func CreateRootCommand(version, branch, commit string) *cobra.Command {
 			ccmd.HelpFunc()(ccmd, args)
 		},
 	}
+	// Including the version in the root command is very convenient.
+	// But, specifying version adds a --version flag to the command.
+	// This is all perfectly nice, but, we don't want a version command
+	// and a version flag, so let's hide the flag for now.
+	rootCmd.PersistentFlags().Bool("version", false, "")
+	rootCmd.PersistentFlags().MarkHidden("version")
 
 	//App Building Commands
 	appBuildCommands := []*cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ func CreateRootCommand(version, branch, commit string) *cobra.Command {
 		Use:                    "corectl",
 		Short:                  "",
 		Long:                   `corectl contains various commands to interact with the Qlik Associative Engine. See respective command for more information`,
+		Version:                version,
 		DisableAutoGenTag:      true,
 		BashCompletionFunction: bashCompletionFunc,
 

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -60,6 +60,9 @@
       "alias": "v",
       "description": "Log extra information",
       "default": "false"
+    },
+    "version": {
+      "default": "false"
     }
   },
   "commands": {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,5 @@ var commit = ""
 var branch = ""
 
 func main() {
-
 	cmd.Execute(version, branch, commit)
 }

--- a/pkg/boot/common_settings.go
+++ b/pkg/boot/common_settings.go
@@ -60,8 +60,9 @@ func (c *CommonSettings) Insecure() bool {
 func (c *CommonSettings) Headers() http.Header {
 	headers := c.GetHeaders()
 
-	//TODO headers.Set("User-Agent", fmt.Sprintf("corectl/%s (%s)", version, runtime.GOOS))
-	headers.Set("User-Agent", "corectl")
+	if agent := headers.Get("User-Agent"); agent == "" {
+		headers.Set("User-Agent", "corectl")
+	}
 	return headers
 }
 

--- a/pkg/dynconf/dyn_settings.go
+++ b/pkg/dynconf/dyn_settings.go
@@ -421,7 +421,9 @@ func (ds *DynSettings) GetHeaders() http.Header {
 			}
 		}
 	}
-	result.Set("User-Agent", ds.GetUserAgent())
+	if agent := ds.GetUserAgent(); agent != "" {
+		result.Set("User-Agent", agent)
+	}
 	return result
 }
 

--- a/pkg/dynconf/dyn_settings.go
+++ b/pkg/dynconf/dyn_settings.go
@@ -3,20 +3,24 @@ package dynconf
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 
 	"github.com/qlik-oss/corectl/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 func ReadSettings(ccmd *cobra.Command) *DynSettings {
 	result := readSettings(ccmd.Flags(), true)
+	root := ccmd.Root()
+	result.rootName = root.Use
+	result.version = root.Version
 	return result
 }
 func ReadSettingsWithoutContext(ccmd *cobra.Command) *DynSettings {
@@ -144,6 +148,9 @@ func getFlagValue(flagset *pflag.FlagSet, flag *pflag.Flag) interface{} {
 }
 
 type DynSettings struct {
+	rootName string
+	version  string
+
 	contextName       string
 	configPath        string
 	configFilePath    string
@@ -414,5 +421,22 @@ func (ds *DynSettings) GetHeaders() http.Header {
 			}
 		}
 	}
+	result.Set("User-Agent", ds.GetUserAgent())
 	return result
+}
+
+// GetUserAgent returns a string representing the User-Agent, consisting of the root name
+// of the associated command, its version and the OS.
+// If no rootName is set, the returned value will be empty.
+func (ds *DynSettings) GetUserAgent() string {
+	var agent string
+	if ds.rootName == "" {
+		return ""
+	}
+	agent = ds.rootName
+	if ds.version != "" {
+		agent += "/" + ds.version
+	}
+	agent += " (" + runtime.GOOS + ")"
+	return agent
 }


### PR DESCRIPTION
The `User-Agent` will now contain information from the root command: name and version (if specified).
It will also include what OS it is run on.
It will default to `corectl` if for some reason (no root command name) the `User-Agent` cannot be determined nicely.

`corectl` with current dev-version on linux will look like:
```
corectl/1.5.3-dev (linux)
```