### PR TITLE
Improve rest debug logs

### DIFF
--- a/pkg/boot/flags.go
+++ b/pkg/boot/flags.go
@@ -44,6 +44,7 @@ func InjectGlobalFlags(command *cobra.Command, hideEngineSpecificFlags bool) {
 		globalFlags.MarkHidden("insecure")
 		globalFlags.MarkHidden("ttl")
 		globalFlags.MarkHidden("app")
+		globalFlags.MarkHidden("traffic")
 	}
 	// Add all global flags to the set of valid config properties.
 	globalFlags.VisitAll(func(flag *pflag.Flag) {

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -207,6 +207,15 @@ func logHeader(header http.Header, prefix string) {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		log.Verbosef("%s%s: %s", prefix, key, strings.Join(header[key], " "))
+		if key == "Authorization" {
+			value := header.Get(key)
+			if strings.HasPrefix("Bearer ", value) {
+				log.Verbosef("%s%s: %s", prefix, key, "Bearer **omitted**")
+			} else {
+				log.Verbosef("%s%s: %s", prefix, key, value)
+			}
+		} else {
+			log.Verbosef("%s%s: %s", prefix, key, header.Get(key))
+		}
 	}
 }

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ type loggableBody struct {
 func (lb *loggableBody) String() string {
 	return string(lb.content)
 }
+
 func (c *RestCaller) CreateLoggableJsonBody(data []byte) io.ReadCloser {
 	buffer := ioutil.NopCloser(bytes.NewBuffer(data))
 	res := loggableBody{
@@ -68,7 +70,7 @@ func (c *RestCaller) Call(method, path string, query map[string]string, body []b
 	url := c.CreateUrl(path, query).String()
 	var req *http.Request
 	var err error
-	if len(body) == 0 {
+	if l := len(body); l == 0 {
 		req, err = http.NewRequest(method, url, nil)
 	} else {
 		buf := bytes.NewBuffer(body)
@@ -158,29 +160,53 @@ func (c *RestCaller) CallRaw(req *http.Request) (*http.Response, error) {
 	for key := range c.Headers() {
 		req.Header.Set(key, c.Headers().Get(key))
 	}
+	log.Verbosef("%s %s", req.Method, req.URL)
+	if c.PrintMode().VerboseMode() {
+		logHeader(req.Header, "> ")
+	}
 
-	var t0 time.Time
-	if log.Traffic {
-		fmt.Fprintln(os.Stderr, req.Method+": "+req.URL.String())
-
-		if req.Body != nil {
-			loggableBody, ok := req.Body.(loggableBody)
-			if ok {
-				log.Info(log.FormatAsJSON(loggableBody.content))
-
+	// TODO support logging more than only JSON?
+	var buf *bytes.Buffer
+	if req.Body != nil {
+		if c.PrintMode().VerboseMode() {
+			contentType := req.Header.Get("Content-Type")
+			if contentType == "" || contentType == "application/json" {
+				// Replace req.Body with a TeeReader which writes to buf on reads so we can log it.
+				buf = bytes.NewBuffer([]byte{})
+				req.Body = ioutil.NopCloser(io.TeeReader(req.Body, buf))
 			}
 		}
-		t0 = time.Now()
 	}
 
+	t0 := time.Now()
 	response, err := client.Do(req)
-	if log.Traffic {
-		t1 := time.Now()
-		interval := t1.Sub(t0)
-		log.Info("Time ", interval)
+	t1 := time.Now()
+
+	if buf != nil {
+		log.Verbose("PAYLOAD:")
+		log.Verbose(log.FormatAsJSON(buf.Bytes()))
 	}
+	if c.PrintMode().VerboseMode() {
+		logHeader(response.Header, "< ")
+	}
+
+	log.Verbose("Time ", t1.Sub(t0))
 	if err != nil {
 		return response, err
 	}
 	return response, nil
+}
+
+// logHeader logs a header (verbose) with the specified prefix.
+func logHeader(header http.Header, prefix string) {
+	keys := make([]string, len(header))
+	i := 0
+	for k := range header {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		log.Verbosef("%s%s: %s", prefix, key, strings.Join(header[key], " "))
+	}
 }


### PR DESCRIPTION
This PR implements curl-like verbose-logging for rest calls.
This entails logging sent and received headers as well as sent payload (in the case it's JSON).
Example:
```
POST https://qcaas.eu.qlikcloud.com/api/v1/csp-origins
> Authorization: Bearer **omitted**
> Content-Type: application/json
> User-Agent: qlik/v0.1.2-dev (linux)
PAYLOAD:
{
  "name": "yo"
}
< Cache-Control: no-store
< Connection: keep-alive
< Content-Length: 118
< Content-Type: application/json; charset=utf-8
< Date: Tue, 21 Apr 2020 14:10:12 GMT
< Pragma: no-cache
< Server: openresty
< Strict-Transport-Security: max-age=15724800; includeSubDomains
Time 363.678923ms
400 Bad Request: Failed to create/update CSP entry: Origin cannot be an empty string (CSP-8)
```