### PR TITLE
fix: Bearer omission

### DIFF
--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -212,7 +212,7 @@ func logHeader(header http.Header, prefix string) {
 	for _, key := range keys {
 		if key == "Authorization" {
 			value := header.Get(key)
-			if strings.HasPrefix("Bearer ", value) {
+			if strings.HasPrefix(value, "Bearer") {
 				log.Verbosef("%s%s: %s", prefix, key, "Bearer **omitted**")
 			} else {
 				log.Verbosef("%s%s: %s", prefix, key, value)


### PR DESCRIPTION
Provide arguments to `HasPrefix` in right order to filter out API-key for readability.