### PR TITLE
Follow redirects on 201 responses

### DIFF
--- a/pkg/boot/common_settings.go
+++ b/pkg/boot/common_settings.go
@@ -170,3 +170,7 @@ func (c *CommonSettings) NoData() bool {
 func (c *CommonSettings) NoSave() bool {
 	return c.GetBoolAllowNoFlag("no-save")
 }
+
+func (c *CommonSettings) OutputPath() string {
+	return c.GetString("output")
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -217,4 +218,24 @@ func Appendln(s string) string {
 		s += "\n"
 	}
 	return s
+}
+
+// WriteToFile writes all the contents of an io.Reader to a new file at the
+// specified path.
+func WriteToFile(path string, body io.Reader) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	p := make([]byte, 256)
+	n, err := body.Read(p)
+	for err == nil {
+		fmt.Fprint(file, string(p[:n]))
+		p = make([]byte, 256)
+		n, err = body.Read(p)
+	}
+	if err != io.EOF {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
`RestCaller` will now automatically follow redirects on 201 responses as part of the `CallReq` function.
If the output from the redirect call is not considered loggable to terminal, an output path will be required (preferably specified with an `output` flag but I'm open for suggestions).

For now, the only content-types not considered loggable are those matching `*/octet-stream`. There are of course many more that shouldn't be logged to terminal, which should perhaps be part of this PR for forward-compatibility.