### PR TITLE
Rest package polish

### DIFF
--- a/pkg/rest/multireadcloser_test.go
+++ b/pkg/rest/multireadcloser_test.go
@@ -1,0 +1,53 @@
+package rest_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/qlik-oss/corectl/pkg/rest"
+)
+
+type readCloser struct {
+	io.Reader
+	closed bool
+}
+
+func NewReadCloser(r io.Reader) *readCloser {
+	return &readCloser{r, false}
+}
+
+func (rc *readCloser) Close() error {
+	if rc.closed {
+		return fmt.Errorf("already closed")
+	}
+	rc.closed = true
+	return nil
+}
+
+func TestMultiReadCloser(t *testing.T) {
+	strs := []string{"Hello", " dear", " reader."}
+	readClosers := make([]io.ReadCloser, len(strs))
+	for i, s := range strs {
+		buf := bytes.NewBuffer([]byte(s))
+		readClosers[i] = NewReadCloser(buf)
+	}
+
+	mrc := rest.MultiReadCloser(readClosers...)
+	b, err := ioutil.ReadAll(mrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := strings.Join(strs, ""); string(b) != s {
+		t.Errorf("Expected %q but got %q", s, string(b))
+	}
+	mrc.Close()
+	for _, rc := range readClosers {
+		if !rc.(*readCloser).closed {
+			t.Error("ReadCloser was not closed!")
+		}
+	}
+}

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -197,11 +197,11 @@ func (c *RestCaller) CallStreaming(method string, path string, query map[string]
 		} else { // Print it all
 			fmt.Fprint(output, string(data))
 		}
-	case "text/plain", "text/html":
-		// We've got some sort of text, safe to stream it to the output
+	case "", "text/plain", "text/html":
+		// We've got some sort of text or an empty body, safe to write it to the output.
 		io.Copy(output, res.Body)
 	default:
-		//We have got something else which we should probably not print to terminal
+		// We have got something else which we should probably not print to terminal.
 		if file, ok := output.(*os.File); ok {
 			fi, _ := file.Stat()
 			// If the file mode contains ModeCharDevice it means it's a terminal.

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -10,30 +10,11 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/qlik-oss/corectl/pkg/log"
 )
-
-type loggableBody struct {
-	io.ReadCloser
-	content []byte
-}
-
-func (lb *loggableBody) String() string {
-	return string(lb.content)
-}
-
-func (c *RestCaller) CreateLoggableJsonBody(data []byte) io.ReadCloser {
-	buffer := ioutil.NopCloser(bytes.NewBuffer(data))
-	res := loggableBody{
-		ReadCloser: buffer,
-		content:    data,
-	}
-	return res
-}
 
 type RestCallerSettings interface {
 	TlsConfig() *tls.Config
@@ -223,7 +204,8 @@ func (c *RestCaller) CallStreaming(method string, path string, query map[string]
 		//We have got something else which we should probably not print to terminal
 		if file, ok := output.(*os.File); ok {
 			fi, _ := file.Stat()
-			if fi.Mode()&os.ModeCharDevice == os.ModeCharDevice {
+			// If the file mode contains ModeCharDevice it means it's a terminal.
+			if fi.Mode()&os.ModeCharDevice != 0 {
 				fmt.Fprintf(output, `Error: Content of type %q cannot be written directly to the terminal
        as it may contain special characters which can mess with your terminal.
        Specify an output location instead, either by flag or by piping the output to a file.
@@ -292,139 +274,4 @@ func (c *RestCaller) CallRaw(req *http.Request) (*http.Response, error) {
 		return response, err
 	}
 	return response, nil
-}
-
-// logHeader logs a header (verbose) with the specified prefix.
-func logHeader(header http.Header, prefix string) {
-	keys := make([]string, len(header))
-	i := 0
-	for k := range header {
-		keys[i] = k
-		i++
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		if key == "Authorization" {
-			value := header.Get(key)
-			if strings.HasPrefix(value, "Bearer") {
-				log.Verbosef("%s%s: %s", prefix, key, "Bearer **omitted**")
-			} else {
-				log.Verbosef("%s%s: %s", prefix, key, value)
-			}
-		} else {
-			log.Verbosef("%s%s: %s", prefix, key, header.Get(key))
-		}
-	}
-}
-
-func getContentType(res *http.Response) string {
-	if typ := res.Header.Get("Content-Type"); typ != "" {
-		typ = strings.Split(typ, ";")[0] // Strip charset utf-8 and such meta-data
-		return typ
-	}
-	p := make([]byte, 512)
-	n, err := res.Body.Read(p)
-	if err != nil {
-		return "application/octet-stream"
-	}
-	p = p[:n]
-	typ := http.DetectContentType(p)
-	log.Verbosef("Detected Content-Type: %q", typ)
-	buf := ioutil.NopCloser(bytes.NewBuffer(p))
-	// Concatenate the body back together with a MultiReadCloser (as we want to be able to close
-	// the body).
-	res.Body = MultiReadCloser(buf, res.Body)
-	return typ
-}
-
-type multiReadCloser struct {
-	io.Reader
-	closers []io.Closer
-}
-
-// MultiReadCloser creates an io.ReadCloser which works as an io.MultiReader with
-// the addition of being able to close all contained io.ReadClosers.
-func MultiReadCloser(readClosers ...io.ReadCloser) io.ReadCloser {
-	readers := make([]io.Reader, len(readClosers))
-	for i, readCloser := range readClosers {
-		readers[i] = readCloser
-	}
-	closers := make([]io.Closer, len(readClosers))
-	for i, readCloser := range readClosers {
-		closers[i] = readCloser
-	}
-	return &multiReadCloser{io.MultiReader(readers...), closers}
-}
-
-func (r *multiReadCloser) Close() error {
-	var errors []string
-	for i, closer := range r.closers {
-		if err := closer.Close(); err != nil {
-			errors = append(errors, fmt.Sprintf("(%d %T): %s", i, closer, err.Error()))
-		}
-	}
-	if len(errors) != 0 {
-		return fmt.Errorf("failed to close: %s", strings.Join(errors, ", "))
-	}
-	return nil
-}
-
-func isJsonResponse(res *http.Response) bool {
-	contentType := res.Header.Get("Content-Type")
-	return strings.HasPrefix(contentType, "application/json")
-}
-
-func filterIdsOnly(bytes []byte) []byte {
-	var result map[string]interface{}
-	err := json.Unmarshal(bytes, &result)
-	if err != nil {
-		log.Warn(err)
-		return nil
-	}
-	var ids string
-	if data, ok := result["data"].([]interface{}); ok {
-		for _, obj := range data {
-			if m, ok := obj.(map[string]interface{}); ok {
-				ids += fmt.Sprint(m["id"]) + "\n"
-			}
-		}
-	} else if id, ok := result["id"].(string); ok {
-		ids += id + "\n"
-	}
-	return []byte(ids)
-}
-
-func filterOutputForPrint(bytes []byte) []byte {
-	var result map[string]interface{}
-	err := json.Unmarshal(bytes, &result)
-	if err != nil {
-		return bytes
-	}
-	data := result["data"]
-	if data != nil {
-		if dataArray, ok := data.([]interface{}); ok {
-			for _, item := range dataArray {
-				removeLinks(item)
-			}
-		} else if dataMap, ok := data.(map[string]interface{}); ok {
-			removeLinks(dataMap)
-		}
-		return marshal(data)
-	}
-	removeLinks(result)
-	return marshal(result)
-}
-
-func marshal(tree interface{}) []byte {
-	return []byte(log.FormatAsJSON(tree))
-}
-
-func removeLinks(resultRaw interface{}) {
-	if result, ok := resultRaw.(map[string]interface{}); ok {
-		if links, ok := result["links"].(map[string]interface{}); ok {
-			if links["self"] != nil || links["next"] != nil || links["prev"] != nil || links["Self"] != nil || links["Next"] != nil || links["Prev"] != nil {
-				delete(result, "links")
-			}
-		}
-	}
 }

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -156,7 +156,12 @@ func (c *RestCaller) CallStreaming(method string, path string, query map[string]
 	// Create the request
 	url := c.CreateUrl(path, query)
 	req, err := http.NewRequest(strings.ToUpper(method), url.String(), body)
-	req.Header.Set("Content-Type", mimeType)
+
+	// Don't set content-type if the passed MIMEtype is invalid.
+	// An empty body does not need to have content-type set.
+	if mimeType != "" {
+		req.Header.Set("Content-Type", mimeType)
+	}
 
 	//Make the actual invocation
 	res, err := c.CallRawAndFollowRedirect(req)

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -1,0 +1,149 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/qlik-oss/corectl/pkg/log"
+)
+
+// logHeader logs a header (verbose) with the specified prefix.
+func logHeader(header http.Header, prefix string) {
+	keys := make([]string, len(header))
+	i := 0
+	for k := range header {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if key == "Authorization" {
+			value := header.Get(key)
+			if strings.HasPrefix(value, "Bearer") {
+				log.Verbosef("%s%s: %s", prefix, key, "Bearer **omitted**")
+			} else {
+				log.Verbosef("%s%s: %s", prefix, key, value)
+			}
+		} else {
+			log.Verbosef("%s%s: %s", prefix, key, header.Get(key))
+		}
+	}
+}
+
+func getContentType(res *http.Response) string {
+	if typ := res.Header.Get("Content-Type"); typ != "" {
+		typ = strings.Split(typ, ";")[0] // Strip charset utf-8 and such meta-data
+		return typ
+	}
+	p := make([]byte, 512)
+	n, err := res.Body.Read(p)
+	if err != nil {
+		return "application/octet-stream"
+	}
+	p = p[:n]
+	typ := http.DetectContentType(p)
+	log.Verbosef("Detected Content-Type: %q", typ)
+	buf := ioutil.NopCloser(bytes.NewBuffer(p))
+	// Concatenate the body back together with a MultiReadCloser (as we want to be able to close
+	// the body).
+	res.Body = MultiReadCloser(buf, res.Body)
+	return typ
+}
+
+type multiReadCloser struct {
+	io.Reader
+	closers []io.Closer
+}
+
+// MultiReadCloser creates an io.ReadCloser which works as an io.MultiReader with
+// the addition of being able to close all contained io.ReadClosers.
+func MultiReadCloser(readClosers ...io.ReadCloser) io.ReadCloser {
+	readers := make([]io.Reader, len(readClosers))
+	for i, readCloser := range readClosers {
+		readers[i] = readCloser
+	}
+	closers := make([]io.Closer, len(readClosers))
+	for i, readCloser := range readClosers {
+		closers[i] = readCloser
+	}
+	return &multiReadCloser{io.MultiReader(readers...), closers}
+}
+
+func (r *multiReadCloser) Close() error {
+	var errors []string
+	for i, closer := range r.closers {
+		if err := closer.Close(); err != nil {
+			errors = append(errors, fmt.Sprintf("(%d %T): %s", i, closer, err.Error()))
+		}
+	}
+	if len(errors) != 0 {
+		return fmt.Errorf("failed to close: %s", strings.Join(errors, ", "))
+	}
+	return nil
+}
+
+func isJsonResponse(res *http.Response) bool {
+	contentType := res.Header.Get("Content-Type")
+	return strings.HasPrefix(contentType, "application/json")
+}
+
+func filterIdsOnly(bytes []byte) []byte {
+	var result map[string]interface{}
+	err := json.Unmarshal(bytes, &result)
+	if err != nil {
+		log.Warn(err)
+		return nil
+	}
+	var ids string
+	if data, ok := result["data"].([]interface{}); ok {
+		for _, obj := range data {
+			if m, ok := obj.(map[string]interface{}); ok {
+				ids += fmt.Sprint(m["id"]) + "\n"
+			}
+		}
+	} else if id, ok := result["id"].(string); ok {
+		ids += id + "\n"
+	}
+	return []byte(ids)
+}
+
+func filterOutputForPrint(bytes []byte) []byte {
+	var result map[string]interface{}
+	err := json.Unmarshal(bytes, &result)
+	if err != nil {
+		return bytes
+	}
+	data := result["data"]
+	if data != nil {
+		if dataArray, ok := data.([]interface{}); ok {
+			for _, item := range dataArray {
+				removeLinks(item)
+			}
+		} else if dataMap, ok := data.(map[string]interface{}); ok {
+			removeLinks(dataMap)
+		}
+		return marshal(data)
+	}
+	removeLinks(result)
+	return marshal(result)
+}
+
+func marshal(tree interface{}) []byte {
+	return []byte(log.FormatAsJSON(tree))
+}
+
+func removeLinks(resultRaw interface{}) {
+	if result, ok := resultRaw.(map[string]interface{}); ok {
+		if links, ok := result["links"].(map[string]interface{}); ok {
+			if links["self"] != nil || links["next"] != nil || links["prev"] != nil || links["Self"] != nil || links["Next"] != nil || links["Prev"] != nil {
+				delete(result, "links")
+			}
+		}
+	}
+}

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -41,6 +41,9 @@ func logHeader(header http.Header, prefix string) {
 // use http.DetectContentType on the first 512 bytes (max) to determine
 // the content-type. The response body will not be consumed, but it's pointer
 // will change.
+//
+// If the body is empty the content-type won't be changed, meaning it will be
+// either empty ("") or whatever it was set to in the header.
 func getContentType(res *http.Response) string {
 	if typ := res.Header.Get("Content-Type"); typ != "" {
 		typ = strings.Split(typ, ";")[0] // Strip charset utf-8 and such meta-data
@@ -48,6 +51,12 @@ func getContentType(res *http.Response) string {
 	}
 	p := make([]byte, 512)
 	n, err := res.Body.Read(p)
+
+	// Empty body, return empty content-type "".
+	if err == io.EOF || n == 0 {
+		log.Verbosef("Empty response body")
+		return ""
+	}
 	if err != nil {
 		return "application/octet-stream"
 	}

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -57,6 +57,7 @@ func getContentType(res *http.Response) string {
 		log.Verbosef("Empty response body")
 		return ""
 	}
+	// Some non-EOF error occured, return "application/octet-stream" which is default.
 	if err != nil {
 		return "application/octet-stream"
 	}


### PR DESCRIPTION
Move output related functions to a separate `pkg/rest/utils.go` file. As many of these things are quite generic, we might want to move them somewhere else in the future, and this way we improve the separation of responsibilities a bit.

I also added comments to some functions and quirky bits of code.