### PR TITLE
Context update fix

### DIFF
--- a/pkg/boot/flags.go
+++ b/pkg/boot/flags.go
@@ -37,7 +37,6 @@ func InjectGlobalFlags(command *cobra.Command, hideEngineSpecificFlags bool) {
 
 	if hideEngineSpecificFlags {
 		globalFlags.MarkHidden("no-data")
-		globalFlags.MarkHidden("insecure")
 		globalFlags.MarkHidden("ttl")
 		globalFlags.MarkHidden("traffic")
 		globalFlags.MarkHidden("certificates")

--- a/pkg/commands/standard/context.go
+++ b/pkg/commands/standard/context.go
@@ -9,6 +9,7 @@ import (
 	"github.com/qlik-oss/corectl/pkg/dynconf"
 	"github.com/qlik-oss/corectl/printer"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func CreateContextCommand(binaryName string) *cobra.Command {
@@ -29,30 +30,7 @@ The information stored will be server url, headers and certificates
 %[1]s context create rd-sense --server localhost:9076 --comment "R&D Qlik Sense deployment"`, binaryName),
 
 		Run: func(ccmd *cobra.Command, args []string) {
-
-			//Check the validity of the certificates folder
-			cfg := dynconf.ReadSettingsWithoutContext(ccmd)
-
-			headers := cfg.GetStringMap("headers")
-			if len(headers) == 0 {
-				headers = nil
-			}
-
-			newSettings := map[string]interface{}{
-				"headers": headers,
-				"comment": cfg.GetString("comment"),
-			}
-
-			certPath := cfg.GetAbsolutePath("certificates")
-			if certPath != "" {
-				newSettings["certificates"] = certPath
-				cfg.GetTLSConfigFromPath("certificates")
-			}
-
-			if !cfg.IsUsingDefaultValue("server") {
-				newSettings["server"] = cfg.GetString("server")
-			}
-
+			newSettings := getContextSettings(ccmd)
 			dynconf.CreateContext(args[0], newSettings)
 		},
 	}, "comment", "api-key")
@@ -68,36 +46,7 @@ The information stored will be server url, headers and certificates
 		ValidArgsFunction: oneArgCompletion,
 
 		Run: func(ccmd *cobra.Command, args []string) {
-
-			// Check the validity of the certificates folder.
-			cfg := dynconf.ReadSettingsWithoutContext(ccmd)
-
-			headers := cfg.GetHeaders()
-			if len(headers) == 0 {
-				headers = nil
-			}
-
-			// Convert from http.Header to map[string]string
-			headerMap := map[string]string{}
-			for key := range headers {
-				headerMap[key] = headers.Get(key)
-			}
-
-			newSettings := map[string]interface{}{
-				"headers": headerMap,
-				"comment": cfg.GetString("comment"),
-			}
-
-			certPath := cfg.GetAbsolutePath("certificates")
-			if certPath != "" {
-				newSettings["certificates"] = certPath
-				cfg.GetTLSConfigFromPath("certificates")
-			}
-
-			if !cfg.IsUsingDefaultValue("server") {
-				newSettings["server"] = cfg.GetString("server")
-			}
-
+			newSettings := getContextSettings(ccmd)
 			dynconf.UpdateContext(args[0], newSettings)
 		},
 	}, "comment", "api-key")
@@ -242,6 +191,30 @@ Contexts are stored locally in your ~/` + dynconf.ContextDir + `/contexts.yml fi
 		clearContextCmd, loginContextCmd, login.CreateInitCommand())
 
 	return contextCmd
+}
+
+// getContextSettings gets all the settings from config and command-line that can be put into
+// a context. (Any setting corresponding to a flag that is present on the passed command.)
+func getContextSettings(ccmd *cobra.Command) map[string]interface{} {
+			// Get the whole current configuration, without context.
+			cfg := dynconf.ReadSettingsWithoutContext(ccmd)
+			configMap := cfg.GetConfigMap()
+
+			// Filter only flags that are present on the command.
+			newSettings := map[string]interface{}{}
+			ccmd.PersistentFlags().VisitAll(func (flag *pflag.Flag) {
+				if v, ok := configMap[flag.Name]; ok {
+					newSettings[flag.Name] = v
+				}
+			})
+			// Ignore config for now as it would be a major change.
+			delete(newSettings, "config")
+			// Overwrite certPath with its absolute path, if present.
+			if certPath := cfg.GetAbsolutePath("certificates"); certPath != "" {
+				newSettings["certificates"] = certPath
+				cfg.GetTLSConfigFromPath("certificates")
+			}
+			return newSettings
 }
 
 type Completion func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)

--- a/pkg/commands/standard/context.go
+++ b/pkg/commands/standard/context.go
@@ -196,25 +196,25 @@ Contexts are stored locally in your ~/` + dynconf.ContextDir + `/contexts.yml fi
 // getContextSettings gets all the settings from config and command-line that can be put into
 // a context. (Any setting corresponding to a flag that is present on the passed command.)
 func getContextSettings(ccmd *cobra.Command) map[string]interface{} {
-			// Get the whole current configuration, without context.
-			cfg := dynconf.ReadSettingsWithoutContext(ccmd)
-			configMap := cfg.GetConfigMap()
+	// Get the whole current configuration, without context.
+	cfg := dynconf.ReadSettingsWithoutContext(ccmd)
+	configMap := cfg.GetConfigMap()
 
-			// Filter only flags that are present on the command.
-			newSettings := map[string]interface{}{}
-			ccmd.Flags().VisitAll(func (flag *pflag.Flag) {
-				if v, ok := configMap[flag.Name]; ok {
-					newSettings[flag.Name] = v
-				}
-			})
-			// Ignore config for now as it would be a major change.
-			delete(newSettings, "config")
-			// Overwrite certPath with its absolute path, if present.
-			if certPath := cfg.GetAbsolutePath("certificates"); certPath != "" {
-				newSettings["certificates"] = certPath
-				cfg.GetTLSConfigFromPath("certificates")
-			}
-			return newSettings
+	// Filter only flags that are present on the command.
+	newSettings := map[string]interface{}{}
+	ccmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if v, ok := configMap[flag.Name]; ok {
+			newSettings[flag.Name] = v
+		}
+	})
+	// Ignore config for now as it would be a major change.
+	delete(newSettings, "config")
+	// Overwrite certPath with its absolute path, if present.
+	if certPath := cfg.GetAbsolutePath("certificates"); certPath != "" {
+		newSettings["certificates"] = certPath
+		cfg.GetTLSConfigFromPath("certificates")
+	}
+	return newSettings
 }
 
 type Completion func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)

--- a/pkg/commands/standard/context.go
+++ b/pkg/commands/standard/context.go
@@ -202,7 +202,7 @@ func getContextSettings(ccmd *cobra.Command) map[string]interface{} {
 
 			// Filter only flags that are present on the command.
 			newSettings := map[string]interface{}{}
-			ccmd.PersistentFlags().VisitAll(func (flag *pflag.Flag) {
+			ccmd.Flags().VisitAll(func (flag *pflag.Flag) {
 				if v, ok := configMap[flag.Name]; ok {
 					newSettings[flag.Name] = v
 				}

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -166,7 +166,7 @@ func (c *RestCaller) CallStreaming(method string, path string, query map[string]
 	//Make the actual invocation
 	res, err := c.CallRawAndFollowRedirect(req)
 	if err != nil {
-		fmt.Println(output, err)
+		fmt.Fprintln(output, err)
 		return err
 	}
 	defer res.Body.Close()

--- a/printer/contexts.go
+++ b/printer/contexts.go
@@ -2,12 +2,13 @@ package printer
 
 import (
 	"fmt"
-	"github.com/qlik-oss/corectl/pkg/dynconf"
-	"github.com/qlik-oss/corectl/pkg/log"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
+	"github.com/qlik-oss/corectl/pkg/dynconf"
+	"github.com/qlik-oss/corectl/pkg/log"
 )
 
 // PrintContext prints all information in a context
@@ -25,12 +26,22 @@ func PrintContext(name string, handler *dynconf.ContextHandler) {
 		return
 	}
 	fmt.Printf("Name: %s\n", name)
-	fmt.Printf("Comment: %s\n", context.GetString("comment"))
-	fmt.Printf("Server: %s\n", context.GetString("server"))
-	fmt.Printf("Certificates: %s\n", context.GetString("certificates"))
-	fmt.Println("Headers:")
-	for k, v := range context.Headers() {
-		fmt.Printf("    %s: %s\n", k, v)
+	keys := make([]string, len(context))
+	i := 0
+	for k := range context {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if k == "headers" {
+			fmt.Println("Headers:")
+			for k, v := range context.Headers() {
+				fmt.Printf("    %s: %s\n", k, v)
+			}
+		} else {
+			fmt.Printf("%s: %v\n", strings.Title(k), context[k])
+		}
 	}
 }
 

--- a/test/corectl_integration_test.go
+++ b/test/corectl_integration_test.go
@@ -49,9 +49,10 @@ func TestReload(t *testing.T) {
 }
 
 func TestContextManagement(t *testing.T) {
+	// Set --app to "" as it is present in the abac config.
 	flags := [][]string{
 		{"--server", *toolkit.EngineJwtIP, "--config", "test/projects/using-jwts/corectl.yml"},
-		{"--server", *toolkit.EngineAbacIP, "--config", "test/projects/abac/corectl.yml"},
+		{"--server", *toolkit.EngineAbacIP, "--config", "test/projects/abac/corectl.yml", "--app", ""},
 	}
 	contexts := []string{t.Name() + "_JWT", t.Name() + "_ABAC"}
 	// Empty params, should default to localhost:9076 when there is no context


### PR DESCRIPTION
This solves an issue current present which is that headers in context will always be overwritten.

It also adds the ability to put more key-value pairs into the context: any global flag and any flag present on the context command itself can be used as key, except for `config`.

Also "unhides" the `--insecure` flag.