### PR TITLE
fix: parse title from qMetaDef

### DIFF
--- a/internal/entities.go
+++ b/internal/entities.go
@@ -33,9 +33,12 @@ type (
 	// PropsWithTitle struct
 	PropsWithTitle struct {
 		*enigma.GenericObjectProperties
-		QMetaDef struct {
-			Title string `json:"title"`
-		} `json:"qMetaDef"`
+		Meta QMetaDef `json:"qMetaDef"`
+	}
+
+	// QMetaDef struct
+	QMetaDef struct {
+		Title string `json:"title"`
 	}
 )
 

--- a/internal/entities.go
+++ b/internal/entities.go
@@ -33,7 +33,9 @@ type (
 	// PropsWithTitle struct
 	PropsWithTitle struct {
 		*enigma.GenericObjectProperties
-		Title string `json:"title"`
+		QMetaDef struct {
+			Title string `json:"title"`
+		} `json:"qMetaDef"`
 	}
 )
 

--- a/internal/object.go
+++ b/internal/object.go
@@ -57,7 +57,7 @@ func ListObjects(ctx context.Context, doc *enigma.Doc) []NamedItemWithType {
 				rawProps, _ := object.GetPropertiesRaw(ctx)
 				propsWithTitle := &PropsWithTitle{}
 				json.Unmarshal(rawProps, propsWithTitle)
-				waitChannel <- &NamedItemWithType{Title: propsWithTitle.Title, ID: item.Id, Type: item.Type}
+				waitChannel <- &NamedItemWithType{Title: propsWithTitle.QMetaDef.Title, ID: item.Id, Type: item.Type}
 			} else {
 				waitChannel <- nil
 			}

--- a/internal/object.go
+++ b/internal/object.go
@@ -57,7 +57,7 @@ func ListObjects(ctx context.Context, doc *enigma.Doc) []NamedItemWithType {
 				rawProps, _ := object.GetPropertiesRaw(ctx)
 				propsWithTitle := &PropsWithTitle{}
 				json.Unmarshal(rawProps, propsWithTitle)
-				waitChannel <- &NamedItemWithType{Title: propsWithTitle.QMetaDef.Title, ID: item.Id, Type: item.Type}
+				waitChannel <- &NamedItemWithType{Title: propsWithTitle.Meta.Title, ID: item.Id, Type: item.Type}
 			} else {
 				waitChannel <- nil
 			}

--- a/test/golden/TestChildObjectsAndFullPropertyTree_object_ls_--json.golden
+++ b/test/golden/TestChildObjectsAndFullPropertyTree_object_ls_--json.golden
@@ -2,7 +2,7 @@
   {
     "qId": "a699ee97-152d-4470-9655-ae7c82d71491",
     "qType": "sheet",
-    "title": ""
+    "title": "My new sheet 2"
   },
   {
     "qId": "gCCkr",
@@ -12,6 +12,6 @@
   {
     "qId": "sZAVcpj",
     "qType": "auto-chart",
-    "title": ""
+    "title": "My new child object"
   }
 ]


### PR DESCRIPTION
`Title` was never populated when listing objects. This PR changes so we populate `Title` from `qMetaDef/title`.

This closes #534.