### PR TITLE
Minimize calls needed to interpret app identifier

### DIFF
--- a/pkg/rest/app.go
+++ b/pkg/rest/app.go
@@ -117,7 +117,6 @@ func isItemID(x string) bool {
 	return re.MatchString(x)
 }
 
-
 func (c *RestCaller) translateItemIdToResourceId(potentialItemId string) string {
 	var result RestDocListItem
 	err := c.CallStd("GET", fmt.Sprintf("v1/items/%s", potentialItemId), "", nil, nil, &result)

--- a/pkg/rest/app_test.go
+++ b/pkg/rest/app_test.go
@@ -5,14 +5,17 @@ import (
 )
 
 func TestIsAppID(t *testing.T) {
-	cases := []struct{id string; exp bool}{
+	cases := []struct {
+		id  string
+		exp bool
+	}{
 		{"", false},
 		{"a-b-c-d-e", false},
 		{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", true},
 		{"6047f2b3-30b4-411e-baab-d3f60a79b95a", true},
 		{"00000000-0000-0000-0000-000000000000", true},
 		{"6047F2B3-30b4-411e-baab-d3f60a79b95a", false}, // Upper case.
-		{"00000000-0000-0000-0000-00000000000", false}, // Wrong size.
+		{"00000000-0000-0000-0000-00000000000", false},  // Wrong size.
 		{"0000000-0000-0000-0000-000000000000", false},
 		{"00000000-000-0000-0000-000000000000", false},
 		{"00000000-0000-000-0000-000000000000", false},
@@ -27,7 +30,10 @@ func TestIsAppID(t *testing.T) {
 }
 
 func TestIsItemID(t *testing.T) {
-	cases := []struct{id string; exp bool}{
+	cases := []struct {
+		id  string
+		exp bool
+	}{
 		{"", false},
 		{"a-b", false},
 		{"aaaaaaaaaaaaaaaaaaaaaaaa", true},
@@ -35,7 +41,7 @@ func TestIsItemID(t *testing.T) {
 		{"5ea0a15906d8b000019ba317", true},
 		{"5eA0a15906d8b000019ba317", false}, // Upper case.
 		{"aaaaaaaaaaa-aaaaaaaaaaaa", false}, // Contains hyphen.
-		{"aaaaaaaaaaaaaaaaaaaaaaa", false}, // Wrong size.
+		{"aaaaaaaaaaaaaaaaaaaaaaa", false},  // Wrong size.
 		{"aaaaaaaaaaaaaaaaaaaaaaaaa", false},
 	}
 	for _, cas := range cases {

--- a/pkg/rest/app_test.go
+++ b/pkg/rest/app_test.go
@@ -1,0 +1,46 @@
+package rest
+
+import (
+	"testing"
+)
+
+func TestIsAppID(t *testing.T) {
+	cases := []struct{id string; exp bool}{
+		{"", false},
+		{"a-b-c-d-e", false},
+		{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", true},
+		{"6047f2b3-30b4-411e-baab-d3f60a79b95a", true},
+		{"00000000-0000-0000-0000-000000000000", true},
+		{"6047F2B3-30b4-411e-baab-d3f60a79b95a", false}, // Upper case.
+		{"00000000-0000-0000-0000-00000000000", false}, // Wrong size.
+		{"0000000-0000-0000-0000-000000000000", false},
+		{"00000000-000-0000-0000-000000000000", false},
+		{"00000000-0000-000-0000-000000000000", false},
+		{"00000000-0000-0000-000-000000000000", false},
+		{"blalba6047f2b3-30b4-411e-baab-d3f60a79b95ablabla", false},
+	}
+	for _, cas := range cases {
+		if isAppID(cas.id) != cas.exp {
+			t.Errorf("Expected %q to be %t", cas.id, cas.exp)
+		}
+	}
+}
+
+func TestIsItemID(t *testing.T) {
+	cases := []struct{id string; exp bool}{
+		{"", false},
+		{"a-b", false},
+		{"aaaaaaaaaaaaaaaaaaaaaaaa", true},
+		{"000000000000000000000000", true},
+		{"5ea0a15906d8b000019ba317", true},
+		{"5eA0a15906d8b000019ba317", false}, // Upper case.
+		{"aaaaaaaaaaa-aaaaaaaaaaaa", false}, // Contains hyphen.
+		{"aaaaaaaaaaaaaaaaaaaaaaa", false}, // Wrong size.
+		{"aaaaaaaaaaaaaaaaaaaaaaaaa", false},
+	}
+	for _, cas := range cases {
+		if isItemID(cas.id) != cas.exp {
+			t.Errorf("Expected %q to be %t", cas.id, cas.exp)
+		}
+	}
+}


### PR DESCRIPTION
Match the known patterns for app IDs, item IDs and regular names so that we only need to make one call to lookup a provided app identifier.

Benefits:
- Makes usage of pure app IDs faster (no extra calls needed).
- When lookups are needed, the debug-logs are still comprehensible since it's only one call and not 3 parallel ones.

*TODO*: Tests.