### PR TITLE
Enable custom output filtering

### DIFF
--- a/pkg/commands/standard/raw.go
+++ b/pkg/commands/standard/raw.go
@@ -15,6 +15,7 @@ import (
 	"github.com/qlik-oss/corectl/pkg/boot"
 	"github.com/qlik-oss/corectl/pkg/commands/engine"
 	"github.com/qlik-oss/corectl/pkg/log"
+	"github.com/qlik-oss/corectl/pkg/rest"
 	"github.com/spf13/cobra"
 )
 
@@ -64,7 +65,11 @@ func CreateRawCommand() *cobra.Command {
 				out = cmd.OutOrStdout()
 			}
 
-			err = restCaller.CallStreaming(method, url, queryParams, mimeType, body, out, false, comm.GetBool("quiet"))
+			var filter rest.Filter
+			if comm.GetBool("quiet") {
+				filter = rest.QuietFilter
+			}
+			err = restCaller.CallStreaming(method, url, queryParams, mimeType, body, out, filter)
 			if err != nil {
 				// Cleanup if we're trying to write to a file.
 				if file, ok := out.(*os.File); ok {

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -287,4 +287,3 @@ func (c *RestCaller) CallRaw(req *http.Request) (*http.Response, error) {
 	}
 	return response, nil
 }
-

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -107,8 +107,10 @@ func (r *multiReadCloser) Close() error {
 	return nil
 }
 
-// filterIdsOnly extracts all "id" fields and prints them.
-func filterIdsOnly(bytes []byte) []byte {
+type Filter func([]byte) []byte
+
+// QuietFilter extracts all "id" fields and prints them.
+func QuietFilter(bytes []byte) []byte {
 	var result map[string]interface{}
 	err := json.Unmarshal(bytes, &result)
 	if err != nil {
@@ -128,9 +130,14 @@ func filterIdsOnly(bytes []byte) []byte {
 	return []byte(ids)
 }
 
-// filterOutpuForPrint removes information not deemed of interest in a CLI context,
+// RawFilter just returns its input.
+func RawFilter(bytes []byte) []byte {
+	return bytes
+}
+
+// StandardFilter removes information not deemed of interest in a CLI context,
 // such as links.
-func filterOutputForPrint(bytes []byte) []byte {
+func StandardFilter(bytes []byte) []byte {
 	var result map[string]interface{}
 	err := json.Unmarshal(bytes, &result)
 	if err != nil {


### PR DESCRIPTION
Adds a functions type:
```
type Filter func([]byte) []byte
```
which can be provided for custom filtering. Also exposing the already present filters for `--quiet`, `--raw` and standard output.