### PR TITLE
Supply version as annotation instead of field

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"context"
-	"github.com/qlik-oss/corectl/pkg/boot"
-	"github.com/qlik-oss/corectl/pkg/commands/engine"
-	"github.com/qlik-oss/corectl/pkg/commands/standard"
 	"os"
 	"strings"
 
+	"github.com/qlik-oss/corectl/pkg/boot"
+	"github.com/qlik-oss/corectl/pkg/commands/engine"
+	"github.com/qlik-oss/corectl/pkg/commands/standard"
 	"github.com/spf13/cobra"
 )
 
@@ -20,25 +20,19 @@ func CreateRootCommand(version, branch, commit string) *cobra.Command {
 		Use:                    "corectl",
 		Short:                  "",
 		Long:                   `corectl contains various commands to interact with the Qlik Associative Engine. See respective command for more information`,
-		Version:                version,
 		DisableAutoGenTag:      true,
 		BashCompletionFunction: bashCompletionFunc,
 
 		Annotations: map[string]string{
 			"x-qlik-visibility": "public",
 			"x-qlik-stability":  "stable",
+			"version":           version,
 		},
 
 		Run: func(ccmd *cobra.Command, args []string) {
 			ccmd.HelpFunc()(ccmd, args)
 		},
 	}
-	// Including the version in the root command is very convenient.
-	// But, specifying version adds a --version flag to the command.
-	// This is all perfectly nice, but, we don't want a version command
-	// and a version flag, so let's hide the flag for now.
-	rootCmd.PersistentFlags().Bool("version", false, "")
-	rootCmd.PersistentFlags().MarkHidden("version")
 
 	//App Building Commands
 	appBuildCommands := []*cobra.Command{

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -61,9 +61,6 @@
       "alias": "v",
       "description": "Log extra information",
       "default": "false"
-    },
-    "version": {
-      "default": "false"
     }
   },
   "commands": {

--- a/pkg/dynconf/dyn_settings.go
+++ b/pkg/dynconf/dyn_settings.go
@@ -20,9 +20,10 @@ func ReadSettings(ccmd *cobra.Command) *DynSettings {
 	result := readSettings(ccmd.Flags(), true)
 	root := ccmd.Root()
 	result.rootName = root.Use
-	result.version = root.Version
+	result.version = root.Annotations["version"]
 	return result
 }
+
 func ReadSettingsWithoutContext(ccmd *cobra.Command) *DynSettings {
 	return readSettings(ccmd.Flags(), false)
 }


### PR DESCRIPTION
Now version is expected to be supplied as an annotation on the root command instead of as a field.
This is more flexible and probably more in line with the intended use of both these fields (`.Version` and `.Annotations`).

This also has the benefit of removing the small, but present, headache that is the hidden (runtime generated) version flag which supplies incomplete version information.