### PR TITLE
Improve error handling in pkg/rest

### DIFF
--- a/pkg/commands/standard/raw.go
+++ b/pkg/commands/standard/raw.go
@@ -83,7 +83,7 @@ func CreateRawCommand() *cobra.Command {
 					// Remove the empty file after a failed call.
 					_ = os.Remove(outputFilePath)
 				}
-				fmt.Fprintln(cmd.ErrOrStderr(), err)
+				fmt.Fprintln(cmd.ErrOrStderr(), log.Appendln(err.Error()))
 				os.Exit(1)
 			}
 		},

--- a/pkg/rest/error_parser.go
+++ b/pkg/rest/error_parser.go
@@ -1,8 +1,8 @@
 package rest
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 )
@@ -16,7 +16,7 @@ type (
 	}
 
 	restError struct {
-		status int
+		status  int
 		message string
 		body    []byte
 	}
@@ -71,8 +71,8 @@ func NewError(res *http.Response) Error {
 		}
 	}
 	restErr := &restError{
-		status: res.StatusCode,
-		body: data,
+		status:  res.StatusCode,
+		body:    data,
 		message: message,
 	}
 	return restErr

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -100,10 +100,10 @@ func (c *RestCaller) CallReq(req *http.Request, result interface{}) error {
 		return err
 	}
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return BuildErrorWithBody(res, data)
+		return NewError(res)
 	}
+	data, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}
@@ -187,12 +187,7 @@ func (c *RestCaller) CallStreaming(method string, path string, query map[string]
 
 	//Something when wrong it seems
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		data, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-		errorWithBody := BuildErrorWithBody(res, data)
-		return errorWithBody
+		return NewError(res)
 	}
 
 	log.Verbose(res.Status)

--- a/pkg/rest/rest_caller.go
+++ b/pkg/rest/rest_caller.go
@@ -185,12 +185,12 @@ func (c *RestCaller) CallStreaming(method string, path string, query map[string]
 	}
 	defer res.Body.Close()
 
+	log.Info(res.Status)
+
 	//Something when wrong it seems
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return NewError(res)
 	}
-
-	log.Verbose(res.Status)
 
 	switch contentType := getContentType(res); contentType {
 	case "application/json":


### PR DESCRIPTION
Adds an `Error` interface to the package which contains a method to check what the status code of the response was.