### PR TITLE
fix: skip schema validation of spec and bump engine version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,25 +69,6 @@ jobs:
             # Execute tests
             docker exec $TEST_CONTAINER /bin/bash -c 'cd /corectl && go test ./test/corectl_integration_test.go --engineStd $TEST_HOST:9076 --engineJwt $TEST_HOST:9176 --engineAbac $TEST_HOST:9276 --engineBadLicenseServer $TEST_HOST:9376 '
 
-  validate:
-    working_directory: ~/corectl
-    docker:
-      - image: circleci/node:8.17.0
-    steps:
-      - checkout
-      - run:
-          name: Install aws-cli
-          command: sudo apt-get update && sudo apt-get install -y awscli
-      - run:
-          name: Download api schema
-          command: aws s3 cp s3://${S3BUCKET}/schema.json ./docs/schema.json --region ${S3BUCKET_REGION}
-      - run:
-          name: Install ajv-cli
-          command: sudo npm install -g ajv-cli@3.3.0
-      - run:
-          name: Validate api spec towards schema
-          command: ajv -s ./docs/schema.json -d ./docs/spec.json --json-pointers=true --all-errors=true
-
   publish:
     working_directory: ~/corectl
     docker:
@@ -122,15 +103,9 @@ workflows:
             tags:
               only:
                 - /v.*/
-      - validate:
-          filters:
-            tags:
-              only:
-                - /v.*/
       - publish:
           requires:
             - build
-            - validate
           filters:
             branches:
               ignore: /.*/

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   qix-engine:
-    image: qlikcore/engine:12.887.0   # Docker image and version
+    image: qlikcore/engine:12.925.0   # Docker image and version
     ports:
       - 9076:9076 # Port exposing the engine on localhost
     command: -S AcceptEULA=${ACCEPT_EULA}  -S DocumentDirectory=/apps # Commands that is passed to the engine container

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 services:
   qix-engine-std:
     container_name: qix-engine-std
-    image: qlikcore/engine:12.887.0
+    image: qlikcore/engine:12.925.0
     ports:
       - 9076:9076
     command: -S AcceptEULA=${ACCEPT_EULA}  -S DocumentDirectory=/apps -S EnableGrpcCustomConnectors=1 -S GrpcConnectorPlugins="testconnector,corectl-test-connector:50051"
@@ -11,7 +11,7 @@ services:
       - ./data:/data
   qix-engine-jwt:
     container_name: qix-engine-jwt
-    image: qlikcore/engine:12.887.0
+    image: qlikcore/engine:12.925.0
     ports:
       - 9176:9076
     command:       -S AcceptEULA=${ACCEPT_EULA} -S DocumentDirectory=/apps -S EnableGrpcCustomConnectors=1 -S GrpcConnectorPlugins="testconnector,corectl-test-connector:50051"      -S ValidateJsonWebTokens=2      -S JsonWebTokenSecret=passw0rd -S
@@ -20,7 +20,7 @@ services:
       - ./data:/data
   qix-engine-abac:
     container_name: qix-engine-abac
-    image: qlikcore/engine:12.887.0
+    image: qlikcore/engine:12.925.0
     ports:
       - 9276:9076
     command: |
@@ -32,7 +32,7 @@ services:
       - ./rules:/rules
   qix-engine-bad-license-server:
     container_name: qix-engine-bad-license-server
-    image: qlikcore/engine:12.887.0
+    image: qlikcore/engine:12.925.0
     ports:
       - 9376:9076
     command: |


### PR DESCRIPTION
* Removes schema validation for the API specification since it is no longer available.
* Bumps engine docker version to `12.925.0`